### PR TITLE
Refactor NFT: Add burn and refactor transfer transitions

### DIFF
--- a/reference/nonfungible-token.scilla
+++ b/reference/nonfungible-token.scilla
@@ -24,7 +24,7 @@ let isApprovedOrOwner =
 
 (* Error events *)
 type Error =
-  | CodeNotAuthorized
+  | CodeNotAuthorised
   | CodeNotFound
   | CodeTokenExists
   | CodeUnexpectedError
@@ -34,7 +34,7 @@ let makeErrorEvent =
   fun (result : Error) =>
     let result_code = 
       match result with
-      | CodeNotAuthorized    => Int32 -1
+      | CodeNotAuthorised    => Int32 -1
       | CodeNotFound         => Int32 -2
       | CodeTokenExists      => Int32 -3
       | CodeUnexpectedError  => Int32 -4
@@ -125,7 +125,7 @@ transition mint(to: ByStr20, tokenId: Uint256)
         event e
       | False =>
         (* Unauthorized transaction*)
-        err = CodeNotAuthorized;
+        err = CodeNotAuthorised;
         MakeError err
       end
     | True =>
@@ -160,7 +160,7 @@ transition burn(tokenId: Uint256)
     match isAuthorised with
     | False =>
       (* Unauthorized transaction *)
-      err = CodeNotAuthorized;
+      err = CodeNotAuthorised;
       MakeError err
     | True =>
       (* Destroy existing token *)
@@ -220,7 +220,7 @@ transition transfer(to: ByStr20, tokenId: Uint256)
       match isAuthorised with
       | False =>
         (* Unauthorized transaction*)
-        err = CodeNotAuthorized;
+        err = CodeNotAuthorised;
         MakeError err
       | True =>
         (* Change tokenOwner for that tokenId *)
@@ -285,7 +285,7 @@ transition approve(to: ByStr20, tokenId: Uint256)
       event e
     | False =>
       (* Unauthorized transaction *)
-      err = CodeNotAuthorized;
+      err = CodeNotAuthorised;
       MakeError err
     end
   end
@@ -307,7 +307,7 @@ transition setApprovalForAll(to: ByStr20, approved: Bool)
     e = {_eventname: "SetApprovalForAllSuccess"; by: _sender; recipient: to; status: approvedStr};
     event e
   | False =>
-    err = CodeNotAuthorized;
+    err = CodeNotAuthorised;
     MakeError err
   end
 end

--- a/reference/nonfungible-token.scilla
+++ b/reference/nonfungible-token.scilla
@@ -11,6 +11,7 @@ let one_msg =
   let nil_msg = Nil {Message} in
   Cons {Message} msg nil_msg
 
+let zero = Uint256 0
 let one = Uint256 1
 
 let addOwnerCount = 
@@ -25,8 +26,14 @@ let subOwnerCount =
 fun (someCurrentCount: Option Uint256) =>
   match someCurrentCount with
   | Some currentCount =>
-    builtin add currentCount one
-  | None => let zero = Uint256 0 in zero
+    let is_zero = builtin eq currentCount zero in
+    match is_zero with
+    | True => None { Uint256 }
+    | False => 
+      let new_count = builtin sub currentCount one in
+      Some { Uint256 } new_count
+    end
+  | None => None { Uint256 }
   end
 
 (* Check if a sender is an operator of the owner, approved for the given ID *)
@@ -43,6 +50,7 @@ type Error =
   | CodeNotAuthorised
   | CodeNotFound
   | CodeTokenExists
+  | CodeUnexpectedError
 
 let makeErrorEvent =
   fun (result : Error) =>
@@ -51,6 +59,7 @@ let makeErrorEvent =
       | CodeNotAuthorised    => Int32 -1
       | CodeNotFound         => Int32 -2
       | CodeTokenExists      => Int32 -3
+      | CodeUnexpectedError  => Int32 -4
       end
     in
     { _eventname : "Error"; code : result_code }
@@ -172,11 +181,17 @@ transition burn(tokenId: Uint256)
       delete tokenApprovals[tokenId];
       (* Deduct from token owner count *)
       someCurrentCount <- ownedTokenCount[tokenOwner];
-      newCount = subOwnerCount someCurrentCount;
-      ownedTokenCount[tokenOwner] := newCount;
-      (* Emit success event *)
-      e = {_eventname: "BurnSuccess"; by: _sender; token: tokenId};
-      event e
+      someNewCount = subOwnerCount someCurrentCount;
+      match someNewCount with
+      | None => 
+        err = CodeUnexpectedError;
+        MakeError err
+      | Some newCount =>
+        ownedTokenCount[tokenOwner] := newCount;
+        (* Emit success event *)
+        e = {_eventname: "BurnSuccess"; by: _sender; token: tokenId};
+        event e
+      end
     end
   end
 end
@@ -224,8 +239,14 @@ transition transfer(to: ByStr20, tokenId: Uint256)
       delete tokenApprovals[tokenId];
       (* Subtract one from previous token owner's count *)
       someFromCount <- ownedTokenCount[tokenOwner];
-      newFromCount = subOwnerCount someFromCount;
-      ownedTokenCount[tokenOwner] := newFromCount;
+      someNewFromCount = subOwnerCount someFromCount;
+      match someNewFromCount with
+      | None => 
+        err = CodeUnexpectedError;
+        MakeError err
+      | Some newFromCount => 
+        ownedTokenCount[tokenOwner] := newFromCount
+      end;
       (* Add one to the new token owner's count *)
       someToCount <- ownedTokenCount[to];
       newToCount = addOwnerCount someToCount;

--- a/reference/nonfungible-token.scilla
+++ b/reference/nonfungible-token.scilla
@@ -148,7 +148,7 @@ transition mint(to: ByStr20, tokenId: Uint256)
   end
 end
 
-(* @dev:    Burn existing tokens. Only tokenOwner or approved Operator can burn a token *)
+(* @dev:    Burn existing tokens. Only tokenOwner or approved operator can burn a token *)
 (* @param:  tokenId - ID of the new token destroyed                                     *)
 (* Returns error message CodeNotFound if token does not exists                          *)
 transition burn(tokenId: Uint256)
@@ -263,7 +263,7 @@ transition transfer(to: ByStr20, tokenId: Uint256)
 end
 
 (* @dev: Approves another address the ability to transfer the given tokenId *)
-(* There can only be one approved address per token at a given time         *)
+(* There can only be one approvedSpender per token at a given time          *)
 (* Absence of entry in tokenApproval indicates there is no approved address *)
 (* param: to      - Address to be approved for the given tokenId            *)
 (* param: tokenId - ID of the token to be approved                          *)

--- a/reference/nonfungible-token.scilla
+++ b/reference/nonfungible-token.scilla
@@ -28,6 +28,7 @@ type Error =
   | CodeNotFound
   | CodeTokenExists
   | CodeUnexpectedError
+  | CodeNotValid
 
 let makeErrorEvent =
   fun (result : Error) =>
@@ -37,6 +38,7 @@ let makeErrorEvent =
       | CodeNotFound         => Int32 -2
       | CodeTokenExists      => Int32 -3
       | CodeUnexpectedError  => Int32 -4
+      | CodeNotValid         => Int32 -5
       end
     in
     { _eventname : "Error"; code : result_code }
@@ -98,28 +100,36 @@ transition mint(to: ByStr20, tokenId: Uint256)
     err = CodeTokenExists;
     MakeError err
   | False =>
-    (* Check if sender is contractOwner *)
-    isContractOwner = builtin eq _sender contractOwner;
-    match isContractOwner with
-    | True =>
-      (* Mint new token *)
-      tokenOwners[tokenId] := to;
-      (* Add to owner's count *)
-      userCount <- ownedTokenCount[to];
-      match userCount with
-      | Some val =>
-        (* Append to existing results *)
-        val = builtin add val one;
-        ownedTokenCount[to] := val
-      | None => 
-        ownedTokenCount[to] := one
-      end;
-      (* Emit success event *)
-      e = {_eventname: "MintSuccess"; by: _sender; recipient: to; token: tokenId};
-      event e
+    (* Prevent transferring of NFT to _this_address *)
+    isContractAddress = builtin eq to _this_address;
+    match isContractAddress with
     | False =>
-      (* Unauthorized transaction*)
-      err = CodeNotAuthorized;
+      (* Check if sender is contractOwner *)
+      isContractOwner = builtin eq _sender contractOwner;
+      match isContractOwner with
+      | True =>
+        (* Mint new token *)
+        tokenOwners[tokenId] := to;
+        (* Add to owner's count *)
+        userCount <- ownedTokenCount[to];
+        match userCount with
+        | Some val =>
+          (* Append to existing results *)
+          val = builtin add val one;
+          ownedTokenCount[to] := val
+        | None => 
+          ownedTokenCount[to] := one
+        end;
+        (* Emit success event *)
+        e = {_eventname: "MintSuccess"; by: _sender; recipient: to; token: tokenId};
+        event e
+      | False =>
+        (* Unauthorized transaction*)
+        err = CodeNotAuthorized;
+        MakeError err
+      end
+    | True =>
+      err = CodeNotValid;
       MakeError err
     end
   end
@@ -157,12 +167,12 @@ transition burn(tokenId: Uint256)
       delete tokenOwners[tokenId];
       delete tokenApprovals[tokenId];
       (* Deduct from token owner count *)
-      userCount <- ownedTokenCount[_sender];
+      userCount <- ownedTokenCount[tokenOwner];
       match userCount with
       | Some val =>
         (* Deduct existing value *)
         val = builtin sub val one;
-        ownedTokenCount[_sender] := val
+        ownedTokenCount[tokenOwner] := val
       | None =>
         err = CodeUnexpectedError;
         MakeError err
@@ -178,62 +188,70 @@ end
 (* @param: to      - Recipient address for the token                  *)
 (* @param: tokenId - ID of the token to be transferred                *)
 transition transfer(to: ByStr20, tokenId: Uint256)
-  (* Check if token exists *)
-  getTokenOwner <- tokenOwners[tokenId];
-  match getTokenOwner with
-  | None =>
-    (* Token do not exists, return error code *)
-    err = CodeNotFound;
-    MakeError err
-  | Some tokenOwner =>
-    (* Check if sender is tokenOwner *)
-    isOwner = builtin eq _sender tokenOwner;
-    getTokenApproval <- tokenApprovals[tokenId];
-    isApproved = match getTokenApproval with
-      | None => False
-      | Some approvedAddress => 
-        (* Check if sender is an approved address *)
-        builtin eq _sender approvedAddress
-      end;
-    (* Check if sender is tokenOwner approvedForAll operator *)
-    getOperatorStatus <- operatorApprovals[tokenOwner][_sender];
-    isApprovedForAll = match getOperatorStatus with
-      | None => False
-      | Some val => val
-      end;
-    (* Check if sender is an authorised personnel *)
-    isAuthorised = isApprovedOrOwner isOwner isApproved isApprovedForAll;
-    match isAuthorised with
-    | False =>
-      (* Unauthorized transaction*)
-      err = CodeNotAuthorized;
+  (* Prevent transferring of NFT to _this_address *)
+  isContractAddress = builtin eq to _this_address;
+  match isContractAddress with
+  | False =>
+    (* Check if token exists *)
+    getTokenOwner <- tokenOwners[tokenId];
+    match getTokenOwner with
+    | None =>
+      (* Token do not exists, return error code *)
+      err = CodeNotFound;
       MakeError err
-    | True =>
-      (* Change tokenOwner for that tokenId *)
-      tokenOwners[tokenId] := to;
-      (* Delete tokenApproval entry for that tokenId *)
-      delete tokenApprovals[tokenId];
-      (* Subtract one from previous token owner's count *)
-      someFromBal <- ownedTokenCount[tokenOwner];
-      match someFromBal with
-      | Some fromBal =>
-        fromBal = builtin sub fromBal one;
-        ownedTokenCount[tokenOwner] := fromBal
-      | None => 
-        err = CodeUnexpectedError;
+    | Some tokenOwner =>
+      (* Check if sender is tokenOwner *)
+      isOwner = builtin eq _sender tokenOwner;
+      getTokenApproval <- tokenApprovals[tokenId];
+      isApproved = match getTokenApproval with
+        | None => False
+        | Some approvedAddress => 
+          (* Check if sender is an approved address *)
+          builtin eq _sender approvedAddress
+        end;
+      (* Check if sender is tokenOwner approvedForAll operator *)
+      getOperatorStatus <- operatorApprovals[tokenOwner][_sender];
+      isApprovedForAll = match getOperatorStatus with
+        | None => False
+        | Some val => val
+        end;
+      (* Check if sender is an authorised personnel *)
+      isAuthorised = isApprovedOrOwner isOwner isApproved isApprovedForAll;
+      match isAuthorised with
+      | False =>
+        (* Unauthorized transaction*)
+        err = CodeNotAuthorized;
         MakeError err
-      end;
-      (* Add one to the new token owner's count *)
-      someToBal <- ownedTokenCount[to];
-      match someToBal with
-      | Some toBal =>
-        toBal = builtin add toBal one;
-        ownedTokenCount[tokenOwner] := toBal
-      | None => ownedTokenCount[tokenOwner] := one
-      end;
-      e = {_eventname: "TransferSuccess"; from: _sender; recipient: to; token: tokenId};
-      event e
+      | True =>
+        (* Change tokenOwner for that tokenId *)
+        tokenOwners[tokenId] := to;
+        (* Delete tokenApproval entry for that tokenId *)
+        delete tokenApprovals[tokenId];
+        (* Subtract one from previous token owner's count *)
+        someFromBal <- ownedTokenCount[tokenOwner];
+        match someFromBal with
+        | Some fromBal =>
+          fromBal = builtin sub fromBal one;
+          ownedTokenCount[tokenOwner] := fromBal
+        | None => 
+          err = CodeUnexpectedError;
+          MakeError err
+        end;
+        (* Add one to the new token owner's count *)
+        someToBal <- ownedTokenCount[to];
+        match someToBal with
+        | Some toBal =>
+          toBal = builtin add toBal one;
+          ownedTokenCount[tokenOwner] := toBal
+        | None => ownedTokenCount[tokenOwner] := one
+        end;
+        e = {_eventname: "TransferSuccess"; from: _sender; recipient: to; token: tokenId};
+        event e
+      end
     end
+  | True =>
+    err = CodeNotValid;
+    MakeError err
   end
 end
 

--- a/reference/nonfungible-token.scilla
+++ b/reference/nonfungible-token.scilla
@@ -11,6 +11,8 @@ let one_msg =
   let nil_msg = Nil {Message} in
   Cons {Message} msg nil_msg
 
+let one = Uint256 1
+
 (* Check if a sender is an operator of the owner, approved for the given ID *)
 (* or is the owner of the token                                             *)
 let isApprovedOrOwner =
@@ -24,7 +26,6 @@ let isApprovedOrOwner =
 type Error =
   | CodeNotAuthorized
   | CodeNotFound
-  | CodeBadRequest
   | CodeTokenExists
   | CodeUnexpectedError
 
@@ -34,9 +35,8 @@ let makeErrorEvent =
       match result with
       | CodeNotAuthorized    => Int32 -1
       | CodeNotFound         => Int32 -2
-      | CodeBadRequest       => Int32 -3
-      | CodeTokenExists      => Int32 -4
-      | CodeUnexpectedError  => Int32 -5
+      | CodeTokenExists      => Int32 -3
+      | CodeUnexpectedError  => Int32 -4
       end
     in
     { _eventname : "Error"; code : result_code }
@@ -46,15 +46,15 @@ let makeErrorEvent =
 (***************************************************)
 
 contract NonfungibleToken
-(contractOwner : ByStr20,
- name : String,
- symbol: String
+(contractOwner: ByStr20,
+  name : String,
+  symbol: String
 )
 
 (* Mutable fields *)
 
 (* Mapping between tokenId to token owner *)
-field tokenOwnerMap: Map Uint256 ByStr20 = Emp Uint256 ByStr20
+field tokenOwners: Map Uint256 ByStr20 = Emp Uint256 ByStr20
 
 (* Mapping from owner to number of owned tokens *)
 field ownedTokenCount: Map ByStr20 Uint256 = Emp ByStr20 Uint256
@@ -64,7 +64,7 @@ field ownedTokenCount: Map ByStr20 Uint256 = Emp ByStr20 Uint256
 field tokenApprovals: Map Uint256 ByStr20 = Emp Uint256 ByStr20
 
 (* Mapping from owner to operator approvals  *)
-field operatorApprovals: Map ByStr20 (Map ByStr20 Bool) 
+field operatorApprovals: Map ByStr20 (Map ByStr20 Bool)
                             = Emp ByStr20 (Map ByStr20 Bool)
 
 (* Emit Errors *)
@@ -73,7 +73,7 @@ procedure MakeError(err : Error)
   event e
 end
 
-(* @notice: Count all NFTs assigned to an owner *)
+(* @notice: Count all NFTs assigned to a tokenOwner *)
 transition balanceOf(address: ByStr20) 
   optionBal <- ownedTokenCount[address];
   balance = 
@@ -85,124 +85,154 @@ transition balanceOf(address: ByStr20)
   event e
 end
 
-(* @dev:    Mint new tokens. Only contractOwner can mint the token *)
-(* @param:  to      - Address of the token recipient               *)
-(* @param:  tokenId - ID of the new token minted                   *)
-(* Returns error message code_token_exist if token exists          *)
-transition transferSingle(to: ByStr20, tokenId: Uint256)
-
-  (* Sender must be the contract owner *)
-  isAuthorized = builtin eq contractOwner _sender;
-  match isAuthorized with
+(* @dev:    Mint new tokens. Only contractOwner can mint. *)
+(* @param:  to      - Address of the token recipient      *)
+(* @param:  tokenId - ID of the new token minted          *)
+(* Returns error message CodeTokenExists if token exists  *)
+transition mint(to: ByStr20, tokenId: Uint256)
+  (* Check if token exists *)
+  tokenExist <- exists tokenOwners[tokenId];
+  match tokenExist with
   | True =>
-    (* Check if token exists *)
-    tokenExist <- exists tokenOwnerMap[tokenId];
-    match tokenExist with
+    (* Token exists, return error code *)
+    err = CodeTokenExists;
+    MakeError err
+  | False =>
+    (* Check if sender is contractOwner *)
+    isContractOwner = builtin eq _sender contractOwner;
+    match isContractOwner with
     | True =>
-      (* Token exists, return error code *)
-      err = CodeTokenExists;
-      MakeError err
-    | False =>
-      (* Mint token *)
-      tokenOwnerMap[tokenId] := to;
-      (* Add to owner count *)
-      userCnt <- ownedTokenCount[to];
-      match userCnt with
+      (* Mint new token *)
+      tokenOwners[tokenId] := to;
+      (* Add to owner's count *)
+      userCount <- ownedTokenCount[to];
+      match userCount with
       | Some val =>
         (* Append to existing results *)
-        newVal= let one = Uint256 1 in builtin add val one;
-        ownedTokenCount[to] := newVal
-      | None =>
-        (* User does not have existing tokens *)
-        newVal = Uint256 1;
-        ownedTokenCount[to] := newVal
+        val = builtin add val one;
+        ownedTokenCount[to] := val
+      | None => 
+        ownedTokenCount[to] := one
       end;
       (* Emit success event *)
-      e = {_eventname: "TransferSingleSuccess"; by: _sender; recipient: to; token: tokenId};
+      e = {_eventname: "MintSuccess"; by: _sender; recipient: to; token: tokenId};
+      event e
+    | False =>
+      (* Unauthorized transaction*)
+      err = CodeNotAuthorized;
+      MakeError err
+    end
+  end
+end
+
+(* @dev:    Burn existing tokens. Only tokenOwner or approved Operator can burn a token *)
+(* @param:  tokenId - ID of the new token destroyed                                     *)
+(* Returns error message CodeNotFound if token does not exists                          *)
+transition burn(tokenId: Uint256)
+  (* Check if token exists *)
+  getTokenOwner <- tokenOwners[tokenId];
+  match getTokenOwner with
+  | None =>
+    (* Token do not exists, return error code *)
+    err = CodeNotFound;
+    MakeError err
+  | Some tokenOwner =>
+    (* Check if sender is tokenOwner *)
+    isOwner = builtin eq _sender tokenOwner;
+    (* Check if sender is tokenOwner approvedForAll operator *)
+    getOperator <- operatorApprovals[tokenOwner][_sender];
+    isApprovedForAll = match getOperator with
+      | None => False
+      | Some val => val
+      end;
+    (* Check if sender is an authorised personnel *)
+    isAuthorised = orb isOwner isApprovedForAll;
+    match isAuthorised with
+    | False =>
+      (* Unauthorized transaction *)
+      err = CodeNotAuthorized;
+      MakeError err
+    | True =>
+      (* Destroy existing token *)
+      delete tokenOwners[tokenId];
+      delete tokenApprovals[tokenId];
+      (* Deduct from token owner count *)
+      userCount <- ownedTokenCount[_sender];
+      match userCount with
+      | Some val =>
+        (* Deduct existing value *)
+        val = builtin sub val one;
+        ownedTokenCount[_sender] := val
+      | None =>
+        err = CodeUnexpectedError;
+        MakeError err
+      end;
+      (* Emit success event *)
+      e = {_eventname: "BurnSuccess"; by: _sender; token: tokenId};
       event e
     end
-  | False =>
-    (* Unauthorized transaction - sender is not the contract owner*)
-    err = CodeNotAuthorized;
-    MakeError err
   end
 end
 
 (* @dev: Transfer the ownership of a given tokenId to another address *)
-(* @param: from    - Current owner address of the token               *)
 (* @param: to      - Recipient address for the token                  *)
 (* @param: tokenId - ID of the token to be transferred                *)
-transition transferFrom(from: ByStr20, to: ByStr20, tokenId: Uint256)
-
-  (* Get tokenOwner ByStr20 *)
-  getTokenOwner <- tokenOwnerMap[tokenId];
+transition transfer(to: ByStr20, tokenId: Uint256)
+  (* Check if token exists *)
+  getTokenOwner <- tokenOwners[tokenId];
   match getTokenOwner with
   | None =>
-    (* Token not found *)
+    (* Token do not exists, return error code *)
     err = CodeNotFound;
-    MakeError err  
+    MakeError err
   | Some tokenOwner =>
-    checkOwner = builtin eq tokenOwner _sender;
-    getApproved <- tokenApprovals[tokenId];
-    checkApproved =
-      match getApproved with
-      | Some app => builtin eq _sender app
+    (* Check if sender is tokenOwner *)
+    isOwner = builtin eq _sender tokenOwner;
+    getTokenApproval <- tokenApprovals[tokenId];
+    isApproved = match getTokenApproval with
       | None => False
+      | Some approvedAddress => 
+        (* Check if sender is an approved address *)
+        builtin eq _sender approvedAddress
       end;
-    getApprovedForAll <- operatorApprovals[tokenOwner][_sender];
-    checkApprovedForAll = 
-      match getApprovedForAll with 
-      | Some True => True 
-      | _ => False 
+    (* Check if sender is tokenOwner approvedForAll operator *)
+    getOperatorStatus <- operatorApprovals[tokenOwner][_sender];
+    isApprovedForAll = match getOperatorStatus with
+      | None => False
+      | Some val => val
       end;
-    (* Checks if the `from` is indeed the owner of the token *)
-    isFromTokenOwner = builtin eq tokenOwner from;
-    match isFromTokenOwner with
+    (* Check if sender is an authorised personnel *)
+    isAuthorised = isApprovedOrOwner isOwner isApproved isApprovedForAll;
+    match isAuthorised with
     | False =>
-      (* From address is not the same as the tokenOwner    *)
-      err = CodeBadRequest;
+      (* Unauthorized transaction*)
+      err = CodeNotAuthorized;
       MakeError err
-    | True => 
-      (* isApprovedOrOwner checks if any of the three conditions are met *)
-      isAuthorized = isApprovedOrOwner checkOwner checkApproved checkApprovedForAll;
-      match isAuthorized with
-      | True =>
-        (* Remove from Approval *)
-        match checkApproved with
-        | True =>
-          (* Remove entry from approvals at the token level *)
-          delete tokenApprovals[tokenId] 
-        | False =>
-        end;
-        (* Change tokenOwnerMap *)
-        tokenOwnerMap[tokenId] := to;
-        (* Subtract one from previous token owner's count *)
-        somePrevBal <- ownedTokenCount[from];
-        match somePrevBal with
-        | Some prevBal =>
-          newBal  = let one = Uint256 1 in builtin sub prevBal one;
-          ownedTokenCount[from] := newBal
-        | None =>
-          err = CodeUnexpectedError;
-          MakeError err 
-        end;
-        (* Add one to the new token owner's count *)
-        userCnt <- ownedTokenCount[to];
-        (* Calculate the new token count value for recipient *)
-        newVal = let one = Uint256 1 in match userCnt with
-        | Some val =>
-          (* Add to existing value *)
-          builtin add val one
-        | None => one
-        end;
-        ownedTokenCount[to] := newVal; 
-        e = {_eventname: "TransferFromSuccess"; from: _sender; recipient: to; token: tokenId}; 
-        event e
-      | False =>
-        (* Unauthorized transaction *)
-        err = CodeNotAuthorized;
+    | True =>
+      (* Change tokenOwner for that tokenId *)
+      tokenOwners[tokenId] := to;
+      (* Delete tokenApproval entry for that tokenId *)
+      delete tokenApprovals[tokenId];
+      (* Subtract one from previous token owner's count *)
+      someFromBal <- ownedTokenCount[tokenOwner];
+      match someFromBal with
+      | Some fromBal =>
+        fromBal = builtin sub fromBal one;
+        ownedTokenCount[tokenOwner] := fromBal
+      | None => 
+        err = CodeUnexpectedError;
         MakeError err
-      end
+      end;
+      (* Add one to the new token owner's count *)
+      someToBal <- ownedTokenCount[to];
+      match someToBal with
+      | Some toBal =>
+        toBal = builtin add toBal one;
+        ownedTokenCount[tokenOwner] := toBal
+      | None => ownedTokenCount[tokenOwner] := one
+      end;
+      e = {_eventname: "TransferSuccess"; from: _sender; recipient: to; token: tokenId};
+      event e
     end
   end
 end
@@ -213,23 +243,21 @@ end
 (* param: to      - Address to be approved for the given tokenId            *)
 (* param: tokenId - ID of the token to be approved                          *)
 transition approve(to: ByStr20, tokenId: Uint256)
-
   (* Get tokenOwner address *)
-  getTokenOwner <- tokenOwnerMap[tokenId];
+  getTokenOwner <- tokenOwners[tokenId];
   match getTokenOwner with
   | None =>
     (* Token not found *)
     err = CodeNotFound;
     MakeError err
   | Some tokenOwner =>
+    isOwner = builtin eq _sender tokenOwner;
     getApprovedForAll <- operatorApprovals[tokenOwner][_sender];
-    checkApprovedForAll = 
-      match getApprovedForAll with 
-      | Some True => True 
-      | _ => False 
+    isApprovedForAll = match getApprovedForAll with
+      | Some val => val
+      | None => False
       end;
-    checkOwner = builtin eq _sender tokenOwner;
-    isAuthorized = orb checkApprovedForAll checkOwner;
+    isAuthorized = orb isOwner isApprovedForAll;
     match isAuthorized with
     | True =>
       (* Add to tokenApproval mapping *)
@@ -249,7 +277,6 @@ end
 (* @param: to       - Address to be set or unset as operator       *)
 (* @param: approved - Status of approval to be set for the address *)
 transition setApprovalForAll(to: ByStr20, approved: Bool)
-
   (* Checks if the _sender is approving himself *)
   isValidOperation = let check = builtin eq _sender to in negb check;
   (* Require the approval to not be the _sender *)
@@ -259,7 +286,7 @@ transition setApprovalForAll(to: ByStr20, approved: Bool)
     operatorApprovals[_sender][to] := approved;
     (* Stringify boolean value to be emitted in the event *)
     approvedStr = bool_to_string approved;
-    e = {_eventname: "SetApprovalForAllSuccess"; from: _sender; recipient: to; status: approvedStr};
+    e = {_eventname: "SetApprovalForAllSuccess"; by: _sender; recipient: to; status: approvedStr};
     event e
   | False =>
     err = CodeNotAuthorized;

--- a/reference/nonfungible-token.scilla
+++ b/reference/nonfungible-token.scilla
@@ -76,7 +76,7 @@ procedure MakeError(err : Error)
 end
 
 (* @notice: Count all NFTs assigned to a tokenOwner *)
-transition balanceOf(address: ByStr20) 
+transition balanceOf(address: ByStr20)
   optionBal <- ownedTokenCount[address];
   balance = 
     match optionBal with
@@ -196,7 +196,7 @@ transition transfer(to: ByStr20, tokenId: Uint256)
     getTokenOwner <- tokenOwners[tokenId];
     match getTokenOwner with
     | None =>
-      (* Token do not exists, return error code *)
+      (* Token does not exists, return error code *)
       err = CodeNotFound;
       MakeError err
     | Some tokenOwner =>

--- a/reference/nonfungible-token.scilla
+++ b/reference/nonfungible-token.scilla
@@ -13,6 +13,22 @@ let one_msg =
 
 let one = Uint256 1
 
+let addOwnerCount = 
+  fun (someCurrentCount: Option Uint256) =>
+    match someCurrentCount with
+    | Some currentCount =>
+      builtin add currentCount one
+    | None => one
+    end
+
+let subOwnerCount = 
+fun (someCurrentCount: Option Uint256) =>
+  match someCurrentCount with
+  | Some currentCount =>
+    builtin add currentCount one
+  | None => let zero = Uint256 0 in zero
+  end
+
 (* Check if a sender is an operator of the owner, approved for the given ID *)
 (* or is the owner of the token                                             *)
 let isApprovedOrOwner =
@@ -27,8 +43,6 @@ type Error =
   | CodeNotAuthorised
   | CodeNotFound
   | CodeTokenExists
-  | CodeUnexpectedError
-  | CodeNotValid
 
 let makeErrorEvent =
   fun (result : Error) =>
@@ -37,8 +51,6 @@ let makeErrorEvent =
       | CodeNotAuthorised    => Int32 -1
       | CodeNotFound         => Int32 -2
       | CodeTokenExists      => Int32 -3
-      | CodeUnexpectedError  => Int32 -4
-      | CodeNotValid         => Int32 -5
       end
     in
     { _eventname : "Error"; code : result_code }
@@ -90,7 +102,8 @@ end
 (* @dev:    Mint new tokens. Only contractOwner can mint. *)
 (* @param:  to      - Address of the token recipient      *)
 (* @param:  tokenId - ID of the new token minted          *)
-(* Returns error message CodeTokenExists if token exists  *)
+(* Returns error message CodeTokenExists if token exists. *)
+(* Revert transition if invalid recipient contract.       *)
 transition mint(to: ByStr20, tokenId: Uint256)
   (* Check if token exists *)
   tokenExist <- exists tokenOwners[tokenId];
@@ -100,36 +113,27 @@ transition mint(to: ByStr20, tokenId: Uint256)
     err = CodeTokenExists;
     MakeError err
   | False =>
-    (* Prevent transferring of NFT to the current contract address *)
-    isContractAddress = builtin eq to _this_address;
-    match isContractAddress with
-    | False =>
-      (* Check if sender is contractOwner *)
-      isContractOwner = builtin eq _sender contractOwner;
-      match isContractOwner with
-      | True =>
-        (* Mint new token *)
-        tokenOwners[tokenId] := to;
-        (* Add to owner's count *)
-        userCount <- ownedTokenCount[to];
-        match userCount with
-        | Some val =>
-          (* Append to existing results *)
-          val = builtin add val one;
-          ownedTokenCount[to] := val
-        | None => 
-          ownedTokenCount[to] := one
-        end;
-        (* Emit success event *)
-        e = {_eventname: "MintSuccess"; by: _sender; recipient: to; token: tokenId};
-        event e
-      | False =>
-        (* Unauthorised transaction*)
-        err = CodeNotAuthorised;
-        MakeError err
-      end
+    (* Check if sender is contractOwner *)
+    isContractOwner = builtin eq _sender contractOwner;
+    match isContractOwner with
     | True =>
-      err = CodeNotValid;
+      (* Mint new token *)
+      tokenOwners[tokenId] := to;
+      (* Add to owner's count *)
+      someCurrentCount <- ownedTokenCount[to];
+      newCount = addOwnerCount someCurrentCount;
+      ownedTokenCount[to] := newCount;
+      (* Emit success event *)
+      e = {_eventname: "MintSuccess"; by: _sender; recipient: to; token: tokenId};
+      event e;
+      (* Send dummy callback message.                                                *)
+      (* Revert transition if invalid recipient contract. Ignore if external address *)
+      msg = { _tag : "transferCallBack"; _recipient : to; _amount : Uint128 0 };
+      msgs = one_msg msg;
+      send msgs
+    | False =>
+      (* Unauthorised transaction*)
+      err = CodeNotAuthorised;
       MakeError err
     end
   end
@@ -167,16 +171,9 @@ transition burn(tokenId: Uint256)
       delete tokenOwners[tokenId];
       delete tokenApprovals[tokenId];
       (* Deduct from token owner count *)
-      userCount <- ownedTokenCount[tokenOwner];
-      match userCount with
-      | Some val =>
-        (* Deduct existing value *)
-        val = builtin sub val one;
-        ownedTokenCount[tokenOwner] := val
-      | None =>
-        err = CodeUnexpectedError;
-        MakeError err
-      end;
+      someCurrentCount <- ownedTokenCount[tokenOwner];
+      newCount = subOwnerCount someCurrentCount;
+      ownedTokenCount[tokenOwner] := newCount;
       (* Emit success event *)
       e = {_eventname: "BurnSuccess"; by: _sender; token: tokenId};
       event e
@@ -187,71 +184,60 @@ end
 (* @dev: Transfer the ownership of a given tokenId to another address *)
 (* @param: to      - Recipient address for the token                  *)
 (* @param: tokenId - ID of the token to be transferred                *)
+(* Returns error message CodeNotFound if token does not exists        *)
+(* Revert transition if invalid recipient contract.                   *)
 transition transfer(to: ByStr20, tokenId: Uint256)
-  (* Prevent transferring of NFT to the current contract address *)
-  isContractAddress = builtin eq to _this_address;
-  match isContractAddress with
-  | False =>
-    (* Check if token exists *)
-    getTokenOwner <- tokenOwners[tokenId];
-    match getTokenOwner with
-    | None =>
-      (* Token does not exists, return error code *)
-      err = CodeNotFound;
-      MakeError err
-    | Some tokenOwner =>
-      (* Check if sender is tokenOwner *)
-      isOwner = builtin eq _sender tokenOwner;
-      getTokenApproval <- tokenApprovals[tokenId];
-      isApproved = match getTokenApproval with
-        | None => False
-        | Some approvedAddress => 
-          (* Check if sender is an approved address *)
-          builtin eq _sender approvedAddress
-        end;
-      (* Check if sender is tokenOwner approvedForAll operator *)
-      getOperatorStatus <- operatorApprovals[tokenOwner][_sender];
-      isApprovedForAll = match getOperatorStatus with
-        | None => False
-        | Some val => val
-        end;
-      (* Check if sender is an authorised personnel *)
-      isAuthorised = isApprovedOrOwner isOwner isApproved isApprovedForAll;
-      match isAuthorised with
-      | False =>
-        (* Unauthorised transaction*)
-        err = CodeNotAuthorised;
-        MakeError err
-      | True =>
-        (* Change tokenOwner for that tokenId *)
-        tokenOwners[tokenId] := to;
-        (* Delete tokenApproval entry for that tokenId *)
-        delete tokenApprovals[tokenId];
-        (* Subtract one from previous token owner's count *)
-        someFromBal <- ownedTokenCount[tokenOwner];
-        match someFromBal with
-        | Some fromBal =>
-          fromBal = builtin sub fromBal one;
-          ownedTokenCount[tokenOwner] := fromBal
-        | None => 
-          err = CodeUnexpectedError;
-          MakeError err
-        end;
-        (* Add one to the new token owner's count *)
-        someToBal <- ownedTokenCount[to];
-        match someToBal with
-        | Some toBal =>
-          toBal = builtin add toBal one;
-          ownedTokenCount[tokenOwner] := toBal
-        | None => ownedTokenCount[tokenOwner] := one
-        end;
-        e = {_eventname: "TransferSuccess"; from: _sender; recipient: to; token: tokenId};
-        event e
-      end
-    end
-  | True =>
-    err = CodeNotValid;
+  (* Check if token exists *)
+  getTokenOwner <- tokenOwners[tokenId];
+  match getTokenOwner with
+  | None =>
+    (* Token does not exists, return error code *)
+    err = CodeNotFound;
     MakeError err
+  | Some tokenOwner =>
+    (* Check if sender is tokenOwner *)
+    isOwner = builtin eq _sender tokenOwner;
+    getTokenApproval <- tokenApprovals[tokenId];
+    isApproved = match getTokenApproval with
+      | None => False
+      | Some approvedAddress => 
+        (* Check if sender is an approved address *)
+        builtin eq _sender approvedAddress
+      end;
+    (* Check if sender is tokenOwner approvedForAll operator *)
+    getOperatorStatus <- operatorApprovals[tokenOwner][_sender];
+    isApprovedForAll = match getOperatorStatus with
+      | None => False
+      | Some val => val
+      end;
+    (* Check if sender is an authorised personnel *)
+    isAuthorised = isApprovedOrOwner isOwner isApproved isApprovedForAll;
+    match isAuthorised with
+    | False =>
+      (* Unauthorised transaction*)
+      err = CodeNotAuthorised;
+      MakeError err
+    | True =>
+      (* Change tokenOwner for that tokenId *)
+      tokenOwners[tokenId] := to;
+      (* Delete tokenApproval entry for that tokenId *)
+      delete tokenApprovals[tokenId];
+      (* Subtract one from previous token owner's count *)
+      someFromCount <- ownedTokenCount[tokenOwner];
+      newFromCount = subOwnerCount someFromCount;
+      ownedTokenCount[tokenOwner] := newFromCount;
+      (* Add one to the new token owner's count *)
+      someToCount <- ownedTokenCount[to];
+      newToCount = addOwnerCount someToCount;
+      ownedTokenCount[tokenOwner] := newToCount;
+      e = {_eventname: "TransferSuccess"; from: _sender; recipient: to; token: tokenId};
+      event e;
+      (* Send dummy callback message.                                                *)
+      (* Revert transition if invalid recipient contract. Ignore if external address *)
+      msg = { _tag : "transferCallBack"; _recipient : to; _amount : Uint128 0 };
+      msgs = one_msg msg;
+      send msgs
+    end
   end
 end
 

--- a/zrcs/zrc-1.md
+++ b/zrcs/zrc-1.md
@@ -38,7 +38,7 @@ The NFT contract must define the following constants for use as error codes for 
 
 | Name                  | Type    | Code | Description                                                     |
 | --------------------- | ------- | ---- | --------------------------------------------------------------- |
-| `CodeNoAuthorized`    | `Int32` | `-1` | Emit when the transition call is unauthorized for a given user. |
+| `CodeNotAuthorised`   | `Int32` | `-1` | Emit when the transition call is unauthorised for a given user. |
 | `CodeNotFound`        | `Int32` | `-2` | Emit when a value is missing.                                   |
 | `CodeTokenExists`     | `Int32` | `-3` | Emit when trying to create a token that already exists.         |
 | `CodeUnexpectedError` | `Int32` | `-4` | Emit when the transition call runs into an unexpected error.    |
@@ -81,7 +81,7 @@ transition mint(to: ByStr20, tokenId: Uint256)
 |           | Name          | Description                | Event Parameters                                                                                                                                                                                                                                                                                                 |
 | --------- | ------------- | -------------------------- | ---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
 | eventName | `MintSuccess` | Minting is successful.     | `by`: `ByStr20`, `recipient`: `ByStr20`, `token`: `Uint256`, where, `by` is the address of caller,`recipient` is the `to` address the token is sent, and `token` is the `tokenId` of the token minted.                                                                                                           |
-| eventName | `Error`       | Minting is not successful. | - emit `CodeTokenExists` if the token already exists.<br>- emit `CodeNotAuthorized` if the transition is called by a user who is not the contract owner.<br>- emit `CodeNotValid` if `to` address is same as this contract's address.<br> **NOTE:** Only the `contractOwner` is allowed to call this transition. |
+| eventName | `Error`       | Minting is not successful. | - emit `CodeTokenExists` if the token already exists.<br>- emit `CodeNotAuthorised` if the transition is called by a user who is not the contract owner.<br>- emit `CodeNotValid` if `to` address is same as this contract's address.<br> **NOTE:** Only the `contractOwner` is allowed to call this transition. |
 
 #### 2. Burn
 
@@ -99,7 +99,7 @@ transition burn(tokenId: Uint256)
 |           | Name          | Description                | Event Parameters                                                                                                                                                                                                                                         |
 | --------- | ------------- | -------------------------- | -------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
 | eventName | `BurnSuccess` | Burning is successful.     | `by`: `ByStr20`, `token`: `Uint256`, where, `by` is the address of caller and `token` is the `tokenID` of the token that has been burned.                                                                                                                |
-| eventName | `Error`       | Burning is not successful. | - emit `CodeNotFound` if the token does not exists.<br>- emit `CodeNotAuthorized` if the transition is called by a user who is not the contract owner.<br>**NOTE:** Only either the `tokenOwner` or approved `operator`s is allowed to call this transition. |
+| eventName | `Error`       | Burning is not successful. | - emit `CodeNotFound` if the token does not exists.<br>- emit `CodeNotAuthorised` if the transition is called by a user who is not the contract owner.<br>**NOTE:** Only either the `tokenOwner` or approved `operator`s is allowed to call this transition. |
 
 #### 3. Approve
 
@@ -120,7 +120,7 @@ transition approve(to: ByStr20, tokenId: Uint256)
 |           | Name             | Description                 | Event Parameters                                                                                                                                                                                                                                        |
 | --------- | ---------------- | --------------------------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
 | eventName | `ApproveSuccess` | Approval is successful.     | `from`: `ByStr20`, `approvedTo`: `ByStr20`, `token`: `Uint256`, where `from` is the address of the caller, and `approvedTo` is argument `to` to the transition.                                                                                         |
-| eventName | `Error`          | Approval is not successful. | - emit `CodeNotFound` if token doesn't exist.<br>- emit `CodeNotAuthorized` if the transition is called by a user who is not authorized to approve. <br>**NOTE:** Only either the `tokenOwner` or approved `operator`s are allowed to call this transition. |
+| eventName | `Error`          | Approval is not successful. | - emit `CodeNotFound` if token doesn't exist.<br>- emit `CodeNotAuthorised` if the transition is called by a user who is not authorized to approve. <br>**NOTE:** Only either the `tokenOwner` or approved `operator`s are allowed to call this transition. |
 
 #### 4. SetApprovalForAll
 
@@ -139,7 +139,7 @@ transition setApprovalForAll(to: ByStr20, approved: Bool)
 |           | Name                       | Description                             | Event Parameters                                                                                                                                                                                                               |
 | --------- | -------------------------- | --------------------------------------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------ |
 | eventName | `SetApprovalForAllSuccess` | Set approval for all is successful.     | `by`: `ByStr20`, `recipient`: `ByStr20`, `status`: `Bool`, where, `by` is the caller, `recipient` is the `to` address to be set approval status for, and `status` is the `approved` status after execution of this transition. |
-| eventName | `Error`                    | Set approval for all is not successful. | - emit `CodeNotAuthorized` if the transition is called by the wrong user, i.e., the caller attempting to approve herself.                                                                                                      |
+| eventName | `Error`                    | Set approval for all is not successful. | - emit `CodeNotAuthorised` if the transition is called by the wrong user, i.e., the caller attempting to approve herself.                                                                                                      |
 
 #### 5. Transfer
 
@@ -158,7 +158,7 @@ transition transfer(to: ByStr20, tokenId: Uint256)
 |           | Name                  | Description                 | Event Parameters                                                                                                                                                                                                                                                                                                                                        |
 | --------- | --------------------- | --------------------------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
 | eventName | `TransferFromSuccess` | Transfer is successful.     | `from`: `ByStr20`, `recipient`: `ByStr20`, `token`: `Uint256`, where, `from` is the caller of the transition, `recipient` is the `to` address and `token` is the `tokenID` of the token that is transferred.                                                                                                                                            |
-| eventName | `Error`               | Transfer is not successful. | - emit `CodeNotValid` if `to` address is this contract's address.<br>- emit `CodeNotFound` if the token does not exists.<br>- emit `CodeNotAuthorized` if the transition is called by a user that is not authorised.<br>**NOTE:** Only either `tokenOwner`, `tokenApproval` or `operator` tied to that `tokenOwner` address can invoke this transition. |
+| eventName | `Error`               | Transfer is not successful. | - emit `CodeNotValid` if `to` address is this contract's address.<br>- emit `CodeNotFound` if the token does not exists.<br>- emit `CodeNotAuthorised` if the transition is called by a user that is not authorised.<br>**NOTE:** Only either `tokenOwner`, `tokenApproval` or `operator` tied to that `tokenOwner` address can invoke this transition. |
 
 #### 6. BalanceOf
 

--- a/zrcs/zrc-1.md
+++ b/zrcs/zrc-1.md
@@ -1,17 +1,14 @@
-
-|  ZRC | Title | Status| Type | Author | Created (yyyy-mm-dd) | Updated (yyyy-mm-dd)
-|--|--|--|--| -- | -- | -- |
-| 1  | Standard for Non Fungible Tokens | Draft | Standard | Gareth Mensah <gareth@zilliqa.com> | 2019-09-28 | 2019-09-28 
-
+| ZRC | Title                            | Status | Type     | Author                             | Created (yyyy-mm-dd) | Updated (yyyy-mm-dd) |
+| --- | -------------------------------- | ------ | -------- | ---------------------------------- | -------------------- | -------------------- |
+| 1   | Standard for Non Fungible Tokens | Draft  | Standard | Gareth Mensah <gareth@zilliqa.com> | 2019-09-28           | 2019-10-09           |
 
 ## I. What are Non Fungible Tokens?
 
 An NFT, or Non Fungible Token is an open standard to create collectible assets. Unlike fungible tokens, each token is completely unique and non-interchangeable with other tokens.
 
-## II. Abstract 
+## II. Abstract
 
-ZRC-1 defines a minimum interface a smart contract must implement to allow unique tokens to be managed, tracked, owned, and traded. 
-
+ZRC-1 defines a minimum interface a smart contract must implement to allow unique tokens to be managed, tracked, owned, and traded.
 
 ## III. Motivation
 
@@ -19,154 +16,169 @@ A standard for NFT can serve as an interface for game creators to create kitties
 
 ## IV. Specification
 
-The NFT contract specification describes: 
-1) the global error codes to be declared in the library part of the contract. 
-2) the names and types of the immutable and mutable variables (aka `fields`). 
-3) the transitions that will allow changing the values of the mutable variables. 
-4) the events to be emitted by them.
+The NFT contract specification describes:
+
+1. the global error codes to be declared in the library part of the contract;
+2. the names and types of the immutable and mutable variables (aka `fields`);
+3. the transitions that will allow the changing of values of the mutable variables;
+4. the events to be emitted by them.
 
 ### A. Roles
 
-| Name | Description
-|--|--|
-| Contract Owner | The owner of the contract initialized by the creator of the contract. |
-| Token Owner | A user (identified by her address) that owns a token.  |
-| Operator | A user (identified) by an address that is approved to make transfers on behalf of a token owner. A token owner can assign other people to be an operator of their tokens. Once assigned, the operators can make any transfer for the token owner on her behalf. |
+| Name            | Description                                                                                                                                                                                                                      |     |
+| --------------- | -------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- | --- |
+| `contractOwner` | The owner of the contract initialized by the creator of the contract.                                                                                                                                                            |
+| `tokenOwner`    | A user (identified by an address) that owns a token tied to a tokenId.                                                                                                                                                           |
+| `tokenApproval` | A user (identified by an address) that can transfer a token tied to a tokenId on behalf of the `tokenOwner`.                                                                                                                     |
+| `operator`      | A user (identified by an address) that is approved to operate all and any tokens owned by another user (identified by another address). The operators can make any transfer, approve, or burn the tokens on behalf of that user. |
 
 ### B. Error Codes
 
 The NFT contract must define the following constants for use as error codes for the `Error` event.
 
-| Name | Type | Code | Description
-|--|--|--|--|
-| `CodeNoAuthorized` | `Int32` | `-1` | Emit when the transition call is unauthorized for a given user.
-| `CodeNotFound` | `Int32` | `-2` | Emit when a value is missing.
-| `CodeBadRequest` | `Int32` | `-3` | Emit when the transition call is somehow incorrect.
-| `CodeTokenExists`| `Int32` | `-4` | Emit when trying to create a token that already exists.
-| `CodeUnexpectedError` | `Int32` | `-5` | Emit when the transition call runs into an unexpected error.
+| Name                  | Type    | Code | Description                                                     |
+| --------------------- | ------- | ---- | --------------------------------------------------------------- |
+| `CodeNoAuthorized`    | `Int32` | `-1` | Emit when the transition call is unauthorized for a given user. |
+| `CodeNotFound`        | `Int32` | `-2` | Emit when a value is missing.                                   |
+| `CodeTokenExists`     | `Int32` | `-3` | Emit when trying to create a token that already exists.         |
+| `CodeUnexpectedError` | `Int32` | `-4` | Emit when the transition call runs into an unexpected error.    |
+| `CodeNotValid`        | `Int32` | `-5` | Emit when the transition call is invalid.                       |
 
 ### C. Immutable Variables
 
-| Name |  Type |Description
-|--|--|--|
+| Name            | Type      | Description                                                           |
+| --------------- | --------- | --------------------------------------------------------------------- |
 | `contractOwner` | `ByStr20` | The owner of the contract initialized by the creator of the contract. |
-| `name` | `String` | The name of the non-fungible token. |
-| `symbol` | `String` | The symbol of the non-fungible token. |
+| `name`          | `String`  | The name of the non-fungible token.                                   |
+| `symbol`        | `String`  | The symbol of the non-fungible token.                                 |
 
 ### D. Mutable Fields
 
-| Name | Type | Description
-|--|--|--|
-| `tokenOwnerMap` | `Map Uint256 ByStr20 = Emp Uint256 ByStr20` | Mapping between `tokenId` (that identifies each token) to its owner. |
-| `ownedTokenCount` | `Map ByStr20 Uint256 = Emp ByStr20 Uint256` | Mapping from token owner to number of owned tokens. |
-| `tokenApprovals` | `Map Uint256 ByStr20 = Emp Uint256 ByStr20` | Mapping between tokenId to approved address. Token owner can approve an address (as an operator) to transfer a particular token (given a tokenId) to other addresses. |
-| `operatorApprovals` | `Map ByStr20 (Map ByStr20 Bool) = Emp ByStr20 (Map ByStr20 Bool)` | Mapping from token owner to operator approvals. |
+| Name                | Type                                                              | Description                                                                                                                                                           |
+| ------------------- | ----------------------------------------------------------------- | --------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| `tokenOwnerMap`     | `Map Uint256 ByStr20 = Emp Uint256 ByStr20`                       | Mapping between `tokenId` (that identifies each token) to its owner.                                                                                                  |
+| `ownedTokenCount`   | `Map ByStr20 Uint256 = Emp ByStr20 Uint256`                       | Mapping from token owner to number of owned tokens.                                                                                                                   |
+| `tokenApprovals`    | `Map Uint256 ByStr20 = Emp Uint256 ByStr20`                       | Mapping between tokenId to approved address. Token owner can approve an address (as an operator) to transfer a particular token (given a tokenId) to other addresses. |
+| `operatorApprovals` | `Map ByStr20 (Map ByStr20 Bool) = Emp ByStr20 (Map ByStr20 Bool)` | Mapping from token owner to operator approvals.                                                                                                                       |
 
 ### E. Transitions
 
-**1. Approve**
+#### 1. Mint
 
 ```ocaml
-(* Approves an address to transfer the given token ID *)
+(* @dev:    Mint new tokens. Only contractOwner can mint. *)
+(* @param:  to      - Address of the token recipient      *)
+(* @param:  tokenId - ID of the new token minted          *)
+(* Returns error message CodeTokenExists if token exists  *)
+transition mint(to: ByStr20, tokenId: Uint256)
+```
+
+|        | Name      | Type      | Description                                          |
+| ------ | --------- | --------- | ---------------------------------------------------- |
+| @param | `to`      | `ByStr20` | Address of the recipient whose balance is increased. |
+| @param | `tokenId` | `Uint256` | Token id of the new to be minted.                    |
+
+|           | Name          | Description                | Event Parameters                                                                                                                                                                                                                                                                                                 |
+| --------- | ------------- | -------------------------- | ---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| eventName | `MintSuccess` | Minting is successful.     | `by`: `ByStr20`, `recipient`: `ByStr20`, `token`: `Uint256`, where, `by` is the address of caller,`recipient` is the `to` address the token is sent, and `token` is the `tokenId` of the token minted.                                                                                                           |
+| eventName | `Error`       | Minting is not successful. | - emit `CodeTokenExists` if the token already exists.<br>- emit `CodeNotAuthorized` if the transition is called by a user who is not the contract owner.<br>- emit `CodeNotValid` if `to` address is same as this contract's address.<br> **NOTE:** Only the `contractOwner` is allowed to call this transition. |
+
+#### 2. Burn
+
+```ocaml
+(* @dev:    Burn existing tokens. Only tokenOwner or approved Operator can burn a token *)
+(* @param:  tokenId - ID of the new token destroyed                                     *)
+(* Returns error message CodeNotFound if token does not exists                          *)
+transition burn(tokenId: Uint256)
+```
+
+|        | Name      | Type      | Description                         |
+| ------ | --------- | --------- | ----------------------------------- |
+| @param | `tokenId` | `Uint256` | Token id of the token to be burned. |
+
+|           | Name          | Description                | Event Parameters                                                                                                                                                                                                                                         |
+| --------- | ------------- | -------------------------- | -------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| eventName | `BurnSuccess` | Burning is successful.     | `by`: `ByStr20`, `token`: `Uint256`, where, `by` is the address of caller and `token` is the `tokenID` of the token that has been burned.                                                                                                                |
+| eventName | `Error`       | Burning is not successful. | - emit `CodeNotFound` if the token does not exists.<br>- emit `CodeNotAuthorized` if the transition is called by a user who is not the contract owner.<br>**NOTE:** Only the `tokenOwner` or an approved `operator`s is allowed to call this transition. |
+
+#### 3. Approve
+
+```ocaml
+(* @dev: Approves another address the ability to transfer the given tokenId *)
+(* There can only be one approved address per token at a given time         *)
+(* Absence of entry in tokenApproval indicates there is no approved address *)
+(* param: to      - Address to be approved for the given tokenId            *)
+(* param: tokenId - ID of the token to be approved                          *)
 transition approve(to: ByStr20, tokenId: Uint256)
 ```
 
-|  | Name | Type| Description
-|--|--|--|--|
-| @param | `to` | `ByStr20` | Address to be approved for the given token id. |
-| @param | `tokenId` | `Uint256` | ID of the token to be approved. |
+|        | Name      | Type      | Description                                    |
+| ------ | --------- | --------- | ---------------------------------------------- |
+| @param | `to`      | `ByStr20` | Address to be approved for the given token id. |
+| @param | `tokenId` | `Uint256` | ID of the token to be approved.                |
 
-|  | Name | Description | Event Parameters
-|--|--|--|--|
-| eventName | `ApproveSuccess` | event is successful. | `from`: `ByStr20`, `approvedTo`: `ByStr20`, `token`: `Uint256`, where `from` is the address of the caller, and `approvedTo` is argument `to` to the transition. |
-| eventName | `Error` | event is not successful. | emit `CodeNotFound` if token doesn't exist.<br/>emit `CodeNotAuthorized` if the transition is called by a user who is not authorized to approve. Only the token owner and the approved operators are allowed to call this transition. |
+|           | Name             | Description                 | Event Parameters                                                                                                                                                                                                                                        |
+| --------- | ---------------- | --------------------------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| eventName | `ApproveSuccess` | Approval is successful.     | `from`: `ByStr20`, `approvedTo`: `ByStr20`, `token`: `Uint256`, where `from` is the address of the caller, and `approvedTo` is argument `to` to the transition.                                                                                         |
+| eventName | `Error`          | Approval is not successful. | - emit `CodeNotFound` if token doesn't exist.<br>- emit `CodeNotAuthorized` if the transition is called by a user who is not authorized to approve. <br>**NOTE:** Only the `tokenOwner` or an approved `operator`s are allowed to call this transition. |
 
-<br/>
-
-**2. ApprovalForAll**
+#### 4. SetApprovalForAll
 
 ```ocaml
-(* Sets or unsets the approval of a given operator *)
+(* @dev: Sets or unsets the approval of a given operator           *)
+(* @param: to       - Address to be set or unset as operator       *)
+(* @param: approved - Status of approval to be set for the address *)
 transition setApprovalForAll(to: ByStr20, approved: Bool)
 ```
 
-|  | Name | Type| Description
-|--|--|--|--|
-| @param | `to` | `ByStr20` | Address to be set or unset as operator. |
-| @param | `approved` | `Bool` | Status of the approval to be set. |
+|        | Name       | Type      | Description                             |
+| ------ | ---------- | --------- | --------------------------------------- |
+| @param | `to`       | `ByStr20` | Address to be set or unset as operator. |
+| @param | `approved` | `Bool`    | Status of the approval to be set.       |
 
-|  | Name | Description | Event Parameters
-|--|--|--|--|
-| eventName | `SetApprovalForAllSuccess` | event is successful. | `from`: `ByStr20`, `recipient`: `ByStr20`, `status`: `Bool`, where, `from` is the caller, `recipient` is the `to` argument and `status` is the `approved` argument of the transition.  |
-| eventName | `Error` | event is not successful. | emit `CodeNotAuthorized` if the transition is called by the wrong user, i.e., the caller attempting to approve herself. |
+|           | Name                       | Description                             | Event Parameters                                                                                                                                                                                                               |
+| --------- | -------------------------- | --------------------------------------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------ |
+| eventName | `SetApprovalForAllSuccess` | Set approval for all is successful.     | `by`: `ByStr20`, `recipient`: `ByStr20`, `status`: `Bool`, where, `by` is the caller, `recipient` is the `to` address to be set approval status for, and `status` is the `approved` status after execution of this transition. |
+| eventName | `Error`                    | Set approval for all is not successful. | - emit `CodeNotAuthorized` if the transition is called by the wrong user, i.e., the caller attempting to approve herself.                                                                                                      |
 
-<br/>
-
-**3. TransferFrom**
+#### 5. Transfer
 
 ```ocaml
-(* Transfer the ownership of a given token ID to another address *)
-transition transferFrom(from: ByStr20, to: ByStr20, tokenId: Uint256)
+(* @dev: Transfer the ownership of a given tokenId to another address *)
+(* @param: to      - Recipient address for the token                  *)
+(* @param: tokenId - ID of the token to be transferred                *)
+transition transfer(to: ByStr20, tokenId: Uint256)
 ```
 
-|  | Name | Type| Description
-|--|--|--|--|
-| @param | `from` | `ByStr20` | Current holder of the token. |
-| @param | `to` | `ByStr20` | Recipient address of the token. |
+|        | Name      | Type      | Description                        |
+| ------ | --------- | --------- | ---------------------------------- |
+| @param | `to`      | `ByStr20` | Recipient address of the token.    |
 | @param | `tokenId` | `Uint256` | Id of the token to be transferred. |
 
-|  | Name | Description | Event Parameters
-|--|--|--|--|
-| eventName | `TransferFromSuccess` | event is successful. | `from`: `ByStr20`, `recipient`: `ByStr20`, `token`:  `Uint256`, where, `from` is the same as the argument `from`, `recipient` is the `to` argument and `token` is the `tokenID` argument of the transition. |
-| eventName | `Error` | event is not successful. | emit `CodeBadRequest` if `from` address is not the same as the token owner.<br/>emit `CodeUnexpectedError` if there's an issue with the token holder's balance.<br/>emit `CodeNotAuthorized` if the transition is called by the wrong user. |
+|           | Name                  | Description                 | Event Parameters                                                                                                                                                                                                                                                                                                                                        |
+| --------- | --------------------- | --------------------------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| eventName | `TransferFromSuccess` | Transfer is successful.     | `from`: `ByStr20`, `recipient`: `ByStr20`, `token`: `Uint256`, where, `from` is the caller of the transition, `recipient` is the `to` address and `token` is the `tokenID` of the token that is transferred.                                                                                                                                            |
+| eventName | `Error`               | Transfer is not successful. | - emit `CodeNotValid` if `to` address is this contract's address.<br>- emit `CodeNotFound` if the token does not exists.<br>- emit `CodeNotAuthorized` if the transition is called by a user that is not authorised.<br>**NOTE:** Only either `tokenOwner`, `tokenApproval` or `operator` tied to that `tokenOwner` address can invoke this transition. |
 
-<br/>
-
-**4. TransferSingle**
+#### 6. BalanceOf
 
 ```ocaml
-(* Mint new tokens. Only contractOwner can mint new tokens. *)
-transition transferSingle(to: ByStr20, tokenId: Uint256)
-```
-
-|  | Name | Type| Description
-|--|--|--|--|
-| @param | `to` | `ByStr20` | Address of the recipient whose balance is increased. |
-| @param | `tokenId` | `Uint256` | Token id of the new token. |
-
-|  | Name | Description | Event Parameters
-|--|--|--|--|
-| eventName | `TransferSingleSuccess` | event is successful. | `by`: `ByStr20`, `recipient`: `ByStr20`, `token`: `Uint256`, where, `by` is the address of caller,`recipient` is the argument `to` and `token` is the `tokenID` argument of the transition. |
-| eventName | `Error` | event is not successful. | emit `CodeTokenExists` if the token already exists.<br/>emit `CodeNotAuthorized` if the transition is called by a user who is not the contract owner. Note that only the `contractOwner` is allowed to call this transition. |
-
-<br/>
-
-**5. BalanceOf**
-
-```ocaml
-(* Count the number of NFTs assigned to a token owner *)
+(* @notice: Count all NFTs assigned to a tokenOwner *)
 transition balanceOf(address: ByStr20)
 ```
 
-|  | Name | Type| Description
-|--|--|--|--|
+|        | Name      | Type      | Description               |
+| ------ | --------- | --------- | ------------------------- |
 | @param | `address` | `ByStr20` | Address of a token owner. |
 
-|  | Name | Description | Event Parameters
-|--|--|--|--|
-| eventName | `BalanceOfSuccess` | event is successful. | `bal`: `Uint128`, which returns the number of tokens owned by a given address. If the user does not own any tokens, then the value returned is `0`. |
-
-<br/>
+|           | Name               | Description                        | Event Parameters                                                                                                                                    |
+| --------- | ------------------ | ---------------------------------- | --------------------------------------------------------------------------------------------------------------------------------------------------- |
+| eventName | `BalanceOfSuccess` | Counting of balance is successful. | `bal`: `Uint128`, which returns the number of tokens owned by a given address. If the user does not own any tokens, then the value returned is `0`. |
 
 ## V. Existing Implementation(s)
 
-
-* [NonfungibleToken](https://github.com/Zilliqa/ZRC/blob/master/reference/nonfungible-token.scilla)
-
-
-<br/>
+- [Non-Fungible Token](https://github.com/Zilliqa/ZRC/blob/master/reference/nonfungible-token.scilla)
 
 ## VI. Copyright
 
 Copyright and related rights waived via [CC0](https://creativecommons.org/publicdomain/zero/1.0/).
-

--- a/zrcs/zrc-1.md
+++ b/zrcs/zrc-1.md
@@ -41,6 +41,7 @@ The NFT contract must define the following constants for use as error codes for 
 | `CodeNotAuthorised`   | `Int32` | `-1` | Emit when the transition call is unauthorised for a given user. |
 | `CodeNotFound`        | `Int32` | `-2` | Emit when a value is missing.                                   |
 | `CodeTokenExists`     | `Int32` | `-3` | Emit when trying to create a token that already exists.         |
+| `CodeUnexpectedError` | `Int32` | `-4` | Emit when the transition call runs into an unexpected error.    |
 
 ### C. Immutable Variables
 
@@ -77,9 +78,9 @@ transition mint(to: ByStr20, tokenId: Uint256)
 | @param | `to`      | `ByStr20` | Address of the recipient whose balance is increased. |
 | @param | `tokenId` | `Uint256` | Token id of the new to be minted.                    |
 
-|           | Name          | Description                | Event Parameters                                                                                                                                                                                                                                                                                                 |
-| --------- | ------------- | -------------------------- | ---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
-| eventName | `MintSuccess` | Minting is successful.     | `by`: `ByStr20`, `recipient`: `ByStr20`, `token`: `Uint256`, where, `by` is the address of caller,`recipient` is the `to` address the token is sent, and `token` is the `tokenId` of the token minted.                                                                                                           |
+|           | Name          | Description                | Event Parameters                                                                                                                                                                                                                   |
+| --------- | ------------- | -------------------------- | ---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| eventName | `MintSuccess` | Minting is successful.     | `by`: `ByStr20`, `recipient`: `ByStr20`, `token`: `Uint256`, where, `by` is the address of caller,`recipient` is the `to` address the token is sent, and `token` is the `tokenId` of the token minted.                             |
 | eventName | `Error`       | Minting is not successful. | - emit `CodeTokenExists` if the token already exists.<br>- emit `CodeNotAuthorised` if the transition is called by a user who is not the contract owner.<br>**NOTE:** Only the `contractOwner` is allowed to call this transition. |
 
 #### 2. Burn
@@ -95,9 +96,9 @@ transition burn(tokenId: Uint256)
 | ------ | --------- | --------- | ----------------------------------- |
 | @param | `tokenId` | `Uint256` | Token id of the token to be burned. |
 
-|           | Name          | Description                | Event Parameters                                                                                                                                                                                                                                         |
-| --------- | ------------- | -------------------------- | -------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
-| eventName | `BurnSuccess` | Burning is successful.     | `by`: `ByStr20`, `token`: `Uint256`, where, `by` is the address of caller and `token` is the `tokenID` of the token that has been burned.                                                                                                                |
+|           | Name          | Description                | Event Parameters                                                                                                                                                                                                                                             |
+| --------- | ------------- | -------------------------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------ |
+| eventName | `BurnSuccess` | Burning is successful.     | `by`: `ByStr20`, `token`: `Uint256`, where, `by` is the address of caller and `token` is the `tokenID` of the token that has been burned.                                                                                                                    |
 | eventName | `Error`       | Burning is not successful. | - emit `CodeNotFound` if the token does not exists.<br>- emit `CodeNotAuthorised` if the transition is called by a user who is not the contract owner.<br>**NOTE:** Only either the `tokenOwner` or approved `operator`s is allowed to call this transition. |
 
 #### 3. Approve
@@ -116,9 +117,9 @@ transition approve(to: ByStr20, tokenId: Uint256)
 | @param | `to`      | `ByStr20` | Address to be approved for the given token id. |
 | @param | `tokenId` | `Uint256` | ID of the token to be approved.                |
 
-|           | Name             | Description                 | Event Parameters                                                                                                                                                                                                                                        |
-| --------- | ---------------- | --------------------------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
-| eventName | `ApproveSuccess` | Approval is successful.     | `from`: `ByStr20`, `approvedTo`: `ByStr20`, `token`: `Uint256`, where `from` is the address of the caller, and `approvedTo` is argument `to` to the transition.                                                                                         |
+|           | Name             | Description                 | Event Parameters                                                                                                                                                                                                                                            |
+| --------- | ---------------- | --------------------------- | ----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| eventName | `ApproveSuccess` | Approval is successful.     | `from`: `ByStr20`, `approvedTo`: `ByStr20`, `token`: `Uint256`, where `from` is the address of the caller, and `approvedTo` is argument `to` to the transition.                                                                                             |
 | eventName | `Error`          | Approval is not successful. | - emit `CodeNotFound` if token doesn't exist.<br>- emit `CodeNotAuthorised` if the transition is called by a user who is not authorized to approve. <br>**NOTE:** Only either the `tokenOwner` or approved `operator`s are allowed to call this transition. |
 
 #### 4. SetApprovalForAll
@@ -156,9 +157,9 @@ transition transfer(to: ByStr20, tokenId: Uint256)
 | @param | `to`      | `ByStr20` | Recipient address of the token.    |
 | @param | `tokenId` | `Uint256` | Id of the token to be transferred. |
 
-|           | Name                  | Description                 | Event Parameters                                                                                                                                                                                                                                                                                                                                        |
-| --------- | --------------------- | --------------------------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
-| eventName | `TransferFromSuccess` | Transfer is successful.     | `from`: `ByStr20`, `recipient`: `ByStr20`, `token`: `Uint256`, where, `from` is the caller of the transition, `recipient` is the `to` address and `token` is the `tokenID` of the token that is transferred.                                                                                                                                            |
+|           | Name                  | Description                 | Event Parameters                                                                                                                                                                                                                                                                   |
+| --------- | --------------------- | --------------------------- | ---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| eventName | `TransferFromSuccess` | Transfer is successful.     | `from`: `ByStr20`, `recipient`: `ByStr20`, `token`: `Uint256`, where, `from` is the caller of the transition, `recipient` is the `to` address and `token` is the `tokenID` of the token that is transferred.                                                                       |
 | eventName | `Error`               | Transfer is not successful. | - emit `CodeNotFound` if the token does not exists.<br>- emit `CodeNotAuthorised` if the transition is called by a user that is not authorised.<br>**NOTE:** Only either `tokenOwner`, `tokenApproval` or `operator` tied to that `tokenOwner` address can invoke this transition. |
 
 #### 6. BalanceOf

--- a/zrcs/zrc-1.md
+++ b/zrcs/zrc-1.md
@@ -99,7 +99,7 @@ transition burn(tokenId: Uint256)
 |           | Name          | Description                | Event Parameters                                                                                                                                                                                                                                         |
 | --------- | ------------- | -------------------------- | -------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
 | eventName | `BurnSuccess` | Burning is successful.     | `by`: `ByStr20`, `token`: `Uint256`, where, `by` is the address of caller and `token` is the `tokenID` of the token that has been burned.                                                                                                                |
-| eventName | `Error`       | Burning is not successful. | - emit `CodeNotFound` if the token does not exists.<br>- emit `CodeNotAuthorized` if the transition is called by a user who is not the contract owner.<br>**NOTE:** Only the `tokenOwner` or an approved `operator`s is allowed to call this transition. |
+| eventName | `Error`       | Burning is not successful. | - emit `CodeNotFound` if the token does not exists.<br>- emit `CodeNotAuthorized` if the transition is called by a user who is not the contract owner.<br>**NOTE:** Only either the `tokenOwner` or approved `operator`s is allowed to call this transition. |
 
 #### 3. Approve
 
@@ -120,7 +120,7 @@ transition approve(to: ByStr20, tokenId: Uint256)
 |           | Name             | Description                 | Event Parameters                                                                                                                                                                                                                                        |
 | --------- | ---------------- | --------------------------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
 | eventName | `ApproveSuccess` | Approval is successful.     | `from`: `ByStr20`, `approvedTo`: `ByStr20`, `token`: `Uint256`, where `from` is the address of the caller, and `approvedTo` is argument `to` to the transition.                                                                                         |
-| eventName | `Error`          | Approval is not successful. | - emit `CodeNotFound` if token doesn't exist.<br>- emit `CodeNotAuthorized` if the transition is called by a user who is not authorized to approve. <br>**NOTE:** Only the `tokenOwner` or an approved `operator`s are allowed to call this transition. |
+| eventName | `Error`          | Approval is not successful. | - emit `CodeNotFound` if token doesn't exist.<br>- emit `CodeNotAuthorized` if the transition is called by a user who is not authorized to approve. <br>**NOTE:** Only either the `tokenOwner` or approved `operator`s are allowed to call this transition. |
 
 #### 4. SetApprovalForAll
 

--- a/zrcs/zrc-1.md
+++ b/zrcs/zrc-1.md
@@ -41,8 +41,6 @@ The NFT contract must define the following constants for use as error codes for 
 | `CodeNotAuthorised`   | `Int32` | `-1` | Emit when the transition call is unauthorised for a given user. |
 | `CodeNotFound`        | `Int32` | `-2` | Emit when a value is missing.                                   |
 | `CodeTokenExists`     | `Int32` | `-3` | Emit when trying to create a token that already exists.         |
-| `CodeUnexpectedError` | `Int32` | `-4` | Emit when the transition call runs into an unexpected error.    |
-| `CodeNotValid`        | `Int32` | `-5` | Emit when the transition call is invalid.                       |
 
 ### C. Immutable Variables
 
@@ -69,7 +67,8 @@ The NFT contract must define the following constants for use as error codes for 
 (* @dev:    Mint new tokens. Only contractOwner can mint. *)
 (* @param:  to      - Address of the token recipient      *)
 (* @param:  tokenId - ID of the new token minted          *)
-(* Returns error message CodeTokenExists if token exists  *)
+(* Returns error message CodeTokenExists if token exists. *)
+(* Revert transition if invalid recipient contract.       *)
 transition mint(to: ByStr20, tokenId: Uint256)
 ```
 
@@ -81,7 +80,7 @@ transition mint(to: ByStr20, tokenId: Uint256)
 |           | Name          | Description                | Event Parameters                                                                                                                                                                                                                                                                                                 |
 | --------- | ------------- | -------------------------- | ---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
 | eventName | `MintSuccess` | Minting is successful.     | `by`: `ByStr20`, `recipient`: `ByStr20`, `token`: `Uint256`, where, `by` is the address of caller,`recipient` is the `to` address the token is sent, and `token` is the `tokenId` of the token minted.                                                                                                           |
-| eventName | `Error`       | Minting is not successful. | - emit `CodeTokenExists` if the token already exists.<br>- emit `CodeNotAuthorised` if the transition is called by a user who is not the contract owner.<br>- emit `CodeNotValid` if `to` address is same as this contract's address.<br> **NOTE:** Only the `contractOwner` is allowed to call this transition. |
+| eventName | `Error`       | Minting is not successful. | - emit `CodeTokenExists` if the token already exists.<br>- emit `CodeNotAuthorised` if the transition is called by a user who is not the contract owner.<br>**NOTE:** Only the `contractOwner` is allowed to call this transition. |
 
 #### 2. Burn
 
@@ -147,6 +146,8 @@ transition setApprovalForAll(to: ByStr20, approved: Bool)
 (* @dev: Transfer the ownership of a given tokenId to another address *)
 (* @param: to      - Recipient address for the token                  *)
 (* @param: tokenId - ID of the token to be transferred                *)
+(* Returns error message CodeNotFound if token does not exists        *)
+(* Revert transition if invalid recipient contract.                   *)
 transition transfer(to: ByStr20, tokenId: Uint256)
 ```
 
@@ -158,7 +159,7 @@ transition transfer(to: ByStr20, tokenId: Uint256)
 |           | Name                  | Description                 | Event Parameters                                                                                                                                                                                                                                                                                                                                        |
 | --------- | --------------------- | --------------------------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
 | eventName | `TransferFromSuccess` | Transfer is successful.     | `from`: `ByStr20`, `recipient`: `ByStr20`, `token`: `Uint256`, where, `from` is the caller of the transition, `recipient` is the `to` address and `token` is the `tokenID` of the token that is transferred.                                                                                                                                            |
-| eventName | `Error`               | Transfer is not successful. | - emit `CodeNotValid` if `to` address is this contract's address.<br>- emit `CodeNotFound` if the token does not exists.<br>- emit `CodeNotAuthorised` if the transition is called by a user that is not authorised.<br>**NOTE:** Only either `tokenOwner`, `tokenApproval` or `operator` tied to that `tokenOwner` address can invoke this transition. |
+| eventName | `Error`               | Transfer is not successful. | - emit `CodeNotFound` if the token does not exists.<br>- emit `CodeNotAuthorised` if the transition is called by a user that is not authorised.<br>**NOTE:** Only either `tokenOwner`, `tokenApproval` or `operator` tied to that `tokenOwner` address can invoke this transition. |
 
 #### 6. BalanceOf
 


### PR DESCRIPTION
- Added a `burn` transition that can only be called by either **tokenOwner** or **operator**
- Changed `transfer` transition, removed `from` address from the logic of the transition. Transition can now be called by either **tokenOwner**, **approvedSpender** or **operator**. Added the removal of **approvedSpender** from the `tokenApprovals` map when transfer is executed.