### PR TITLE
fix(zrc-2): Add throw to error branches

### DIFF
--- a/reference/FungibleToken.scilla
+++ b/reference/FungibleToken.scilla
@@ -127,13 +127,15 @@ procedure AuthorizedBurnIfSufficientBalance(from: ByStr20, amount: Uint128)
   match get_bal with
   | None => 
     err = CodeInsufficientFunds;
-    IssueErrorEvent err
+    IssueErrorEvent err;
+    throw
   | Some bal =>
     can_burn = uint128_le amount bal;
     match can_burn with
     | False =>
       err = CodeInsufficientFunds;
-      IssueErrorEvent err
+      IssueErrorEvent err;
+      throw
     | True =>
       (* Subtract amount from 'from' *)
       new_balance = builtin sub bal amount;
@@ -168,11 +170,13 @@ procedure AuthorizedMoveIfSufficientBalance(from: ByStr20, to: ByStr20, amount: 
     | False =>
       (* Balance not sufficient *)
       err = CodeInsufficientFunds;
-      IssueErrorEvent err
+      IssueErrorEvent err;
+      throw
     end
   | None =>
     err = CodeNotFound;
-    IssueErrorEvent err
+    IssueErrorEvent err;
+    throw
   end
 end
 
@@ -209,7 +213,8 @@ transition Mint(recipient: ByStr20, amount: Uint128)
    match is_owner with
     | False =>
       err = CodeNotAuthorized;
-      IssueErrorEvent err
+      IssueErrorEvent err;
+      throw
     | True =>
       AuthorizedMint recipient amount;
       (* Prevent sending to a contract address that does not support transfers of token *)
@@ -230,7 +235,8 @@ transition Burn(burn_account: ByStr20, amount: Uint128)
     match is_owner with
     | False =>
       err = CodeNotAuthorized;
-      IssueErrorEvent err
+      IssueErrorEvent err;
+      throw
     | True =>
       AuthorizedBurnIfSufficientBalance burn_account amount;
       msg_to_sender = {_tag : "BurnSuccessCallBack"; _recipient : _sender; _amount : zero; 
@@ -382,7 +388,8 @@ transition OperatorSend(from: ByStr20, to: ByStr20, amount: Uint128)
   match is_approved with
     | False =>
       err = CodeNotAuthorized;
-      IssueErrorEvent err
+      IssueErrorEvent err;
+      throw
     | True =>
       AuthorizedMoveIfSufficientBalance from to amount;
       e = {_eventname : "OperatorSendSuccess"; initiator : _sender; sender : from; recipient : to; amount : amount};
@@ -407,13 +414,15 @@ transition TransferFrom(from: ByStr20, to: ByStr20, amount: Uint128)
   match get_bal with
   | None => 
     err = CodeNotFound;
-    IssueErrorEvent err
+    IssueErrorEvent err;
+    throw
   | Some bal =>
     get_spender_allowed <- allowances_map[from][_sender];
     match get_spender_allowed with
     | None =>
       err = CodeNotAuthorized;
-      IssueErrorEvent err
+      IssueErrorEvent err;
+      throw
     | Some allowed =>
       min = min_int bal allowed;
       can_do = uint128_le amount min;
@@ -433,7 +442,8 @@ transition TransferFrom(from: ByStr20, to: ByStr20, amount: Uint128)
         send msgs
       | False =>
         err = CodeInsufficientFunds;
-        IssueErrorEvent err
+        IssueErrorEvent err;
+        throw
       end
     end
   end

--- a/reference/FungibleToken.scilla
+++ b/reference/FungibleToken.scilla
@@ -103,9 +103,10 @@ field allowances_map: Map ByStr20 (Map ByStr20 Uint128)
 (**************************************)
 
 (* Emit Errors *)
-procedure IssueErrorEvent(err : Error)
+procedure ThrowError(err : Error)
   e = make_error_event err;
-  event e
+  event e;
+  throw
 end
 
 (* Mint Tokens *)
@@ -127,15 +128,13 @@ procedure AuthorizedBurnIfSufficientBalance(from: ByStr20, amount: Uint128)
   match get_bal with
   | None => 
     err = CodeInsufficientFunds;
-    IssueErrorEvent err;
-    throw
+    ThrowError err
   | Some bal =>
     can_burn = uint128_le amount bal;
     match can_burn with
     | False =>
       err = CodeInsufficientFunds;
-      IssueErrorEvent err;
-      throw
+      ThrowError err
     | True =>
       (* Subtract amount from 'from' *)
       new_balance = builtin sub bal amount;
@@ -170,13 +169,11 @@ procedure AuthorizedMoveIfSufficientBalance(from: ByStr20, to: ByStr20, amount: 
     | False =>
       (* Balance not sufficient *)
       err = CodeInsufficientFunds;
-      IssueErrorEvent err;
-      throw
+      ThrowError err
     end
   | None =>
     err = CodeNotFound;
-    IssueErrorEvent err;
-    throw
+    ThrowError err
   end
 end
 
@@ -213,8 +210,7 @@ transition Mint(recipient: ByStr20, amount: Uint128)
    match is_owner with
     | False =>
       err = CodeNotAuthorized;
-      IssueErrorEvent err;
-      throw
+      ThrowError err
     | True =>
       AuthorizedMint recipient amount;
       (* Prevent sending to a contract address that does not support transfers of token *)
@@ -235,8 +231,7 @@ transition Burn(burn_account: ByStr20, amount: Uint128)
     match is_owner with
     | False =>
       err = CodeNotAuthorized;
-      IssueErrorEvent err;
-      throw
+      ThrowError err
     | True =>
       AuthorizedBurnIfSufficientBalance burn_account amount;
       msg_to_sender = {_tag : "BurnSuccessCallBack"; _recipient : _sender; _amount : zero; 
@@ -255,9 +250,9 @@ transition AuthorizeOperator(operator: ByStr20)
   is_sender = builtin eq operator _sender;
   match is_sender with
   | True => 
-    (* _sender is authorizing self as operator, return error code *)
+    (* _sender is authorizing self as operator, throw error code *)
     err = CodeNotAuthorized;
-    IssueErrorEvent err
+    ThrowError err
   | False =>
     is_default_operator =  is_default_operator f_eq operator default_operators;
     match is_default_operator with
@@ -286,9 +281,9 @@ transition RevokeOperator(operator: ByStr20)
     get_operator <- operators_map[_sender][operator];
     match get_operator with
     | None =>
-      (* Operator to be removed not found, error *)
+      (* Operator to be removed not found, throw error *)
       err = CodeNotFound;
-      IssueErrorEvent err
+      ThrowError err
     | Some status =>
       delete operators_map[_sender][operator];
       e = {_eventname : "RevokeOperatorSuccess"; revoker : _sender; revoked_operator : operator};
@@ -312,7 +307,7 @@ transition IncreaseAllowance(spender: ByStr20, amount: Uint128)
   match is_owner with
   | True =>
     err = CodeNotAuthorized;
-    IssueErrorEvent err
+    ThrowError err
   | False =>
     get_current_allowance <- allowances_map[_sender][spender];
     current_allowance =
@@ -336,7 +331,7 @@ transition DecreaseAllowance(spender: ByStr20, amount: Uint128)
   match is_owner with
   | True =>
     err = CodeNotAuthorized;
-    IssueErrorEvent err
+    ThrowError err
   | False =>
     get_current_allowance <- allowances_map[_sender][spender];
     current_allowance =
@@ -388,8 +383,7 @@ transition OperatorSend(from: ByStr20, to: ByStr20, amount: Uint128)
   match is_approved with
     | False =>
       err = CodeNotAuthorized;
-      IssueErrorEvent err;
-      throw
+      ThrowError err
     | True =>
       AuthorizedMoveIfSufficientBalance from to amount;
       e = {_eventname : "OperatorSendSuccess"; initiator : _sender; sender : from; recipient : to; amount : amount};
@@ -414,15 +408,13 @@ transition TransferFrom(from: ByStr20, to: ByStr20, amount: Uint128)
   match get_bal with
   | None => 
     err = CodeNotFound;
-    IssueErrorEvent err;
-    throw
+    ThrowError err
   | Some bal =>
     get_spender_allowed <- allowances_map[from][_sender];
     match get_spender_allowed with
     | None =>
       err = CodeNotAuthorized;
-      IssueErrorEvent err;
-      throw
+      ThrowError err
     | Some allowed =>
       min = min_int bal allowed;
       can_do = uint128_le amount min;
@@ -442,8 +434,7 @@ transition TransferFrom(from: ByStr20, to: ByStr20, amount: Uint128)
         send msgs
       | False =>
         err = CodeInsufficientFunds;
-        IssueErrorEvent err;
-        throw
+        ThrowError err
       end
     end
   end


### PR DESCRIPTION
If a contract is calling a subsequent contract in 1 matching branch (success branch), it needs to `throw` in the other branch (error branch) to prevent state errors during chain calls.