### PR TITLE
Updated the event name for the Transfer transition

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,3 +1,3 @@
 ########## Global owners ##########
 
-*           @AmritKumar @jjcnn @vaivaswatha @edisonljh @evesnow91 @anton-trunov
+*           @AmritKumar @jjcnn @vaivaswatha @edisonljh @evesnow91 @anton-trunov @arnavvohra

--- a/reference/FungibleToken.scilla
+++ b/reference/FungibleToken.scilla
@@ -327,7 +327,7 @@ end
 (* @param amount:     Amount of tokens to be sent.                                  *)
 transition Transfer(to: ByStr20, amount: Uint128)
   AuthorizedMoveIfSufficientBalance _sender to amount;
-  e = {_eventname : "Transfer"; sender : _sender; recipient : to; amount : amount};
+  e = {_eventname : "TransferSuccess"; sender : _sender; recipient : to; amount : amount};
   event e;
   (* Prevent sending to a contract address that does not support transfers of token *)
   msg_to_recipient = {_tag : "RecipientAcceptTransfer"; _recipient : to; _amount : zero; 

--- a/reference/FungibleToken.scilla
+++ b/reference/FungibleToken.scilla
@@ -19,20 +19,34 @@ fun (msg2 : Message) =>
 
 (* Error events *)
 type Error =
-  | CodeNotAuthorized
-  | CodeNotFound
+  | CodeNotOwner
+  | CodeIsSender
+  | CodeNotApprovedOperator
+  | CodeNotApprovedSpender
+  | CodeNoBalance
   | CodeInsufficientFunds
+  | CodeInsufficientAllowanceOrFunds
 
-let make_error_event =
+let make_error =
   fun (result : Error) =>
     let result_code = 
       match result with
-      | CodeNotAuthorized     => Int32 -1
-      | CodeNotFound          => Int32 -2
-      | CodeInsufficientFunds => Int32 -3
+      | CodeNotOwner                     => Int32 -1
+      | CodeIsSender                     => Int32 -2
+      | CodeNotApprovedOperator          => Int32 -3
+      | CodeNotApprovedSpender           => Int32 -4
+      | CodeNoBalance                    => Int32 -5
+      | CodeInsufficientFunds            => Int32 -6
+      | CodeInsufficientAllowanceOrFunds => Int32 -7
       end
     in
-    { _eventname : "Error"; code : result_code }
+    { _exception : "Error"; code : result_code }
+  
+let zero = Uint128 0
+
+(* Dummy user-defined ADT *)
+type Unit =
+| Unit
 
 let min_int =
   fun (a : Uint128) => fun (b : Uint128) =>
@@ -53,20 +67,12 @@ let f_eq =
 (* Instantiate a type function to test membership in a list *)
 let is_default_operator = @list_mem ByStr20
 
-(* A util function to get balance of token_owner *)
-let get_balance =
-  fun (some_bal: Option Uint128) =>
-  match some_bal with
-  | Some bal => bal
-  | None => Uint128 0
+let get_val =
+  fun (some_val: Option Uint128) =>
+  match some_val with
+  | Some val => val
+  | None => zero
   end
-
-(* Dummy user-defined ADT *)
-type Unit =
-| Unit
-
-let zero = Uint128 0
-let one = Uint128 1
 
 (***************************************************)
 (*             The contract definition             *)
@@ -104,16 +110,50 @@ field allowances_map: Map ByStr20 (Map ByStr20 Uint128)
 
 (* Emit Errors *)
 procedure ThrowError(err : Error)
-  e = make_error_event err;
-  event e;
-  throw
+  e = make_error err;
+  throw e
 end
 
-(* Mint Tokens *)
+procedure IsOwner(address: ByStr20)
+  is_owner = builtin eq contract_owner address;
+  match is_owner with
+  | True =>
+  | False =>
+    err = CodeNotOwner;
+    ThrowError err
+  end
+end
+
+procedure IsNotSender(address: ByStr20)
+  is_sender = builtin eq _sender address;
+  match is_sender with
+  | True =>
+    err = CodeIsSender;
+    ThrowError err
+  | False =>
+  end
+end
+
+procedure IsApprovedOperator(token_owner: ByStr20, operator: ByStr20)
+  is_operator_approved <- exists operators_map[token_owner][operator];
+  is_default_operator = is_default_operator f_eq operator default_operators;
+  is_revoked_operator <- exists revoked_default_operators[token_owner][operator];
+  is_default_operator_approved = 
+    let is_not_revoked_operator = negb is_revoked_operator in 
+    andb is_not_revoked_operator is_default_operator;
+  is_approved = orb is_operator_approved is_default_operator_approved;
+  match is_approved with
+  | True =>
+  | False =>
+    err = CodeNotApprovedOperator;
+    ThrowError err
+  end
+end
+
 procedure AuthorizedMint(recipient: ByStr20, amount: Uint128) 
-  get_bal <- balances_map[recipient];
-  balance = get_balance get_bal;
-  new_balance = builtin add amount balance;
+  some_bal <- balances_map[recipient];
+  bal = get_val some_bal;
+  new_balance = builtin add amount bal;
   balances_map[recipient] := new_balance;
   current_total_supply <- total_supply;
   new_total_supply = builtin add current_total_supply amount;
@@ -122,21 +162,14 @@ procedure AuthorizedMint(recipient: ByStr20, amount: Uint128)
   event e
 end
 
-(* Burn Tokens *)
 procedure AuthorizedBurnIfSufficientBalance(from: ByStr20, amount: Uint128)
   get_bal <- balances_map[from];
   match get_bal with
-  | None => 
-    err = CodeInsufficientFunds;
-    ThrowError err
   | Some bal =>
     can_burn = uint128_le amount bal;
     match can_burn with
-    | False =>
-      err = CodeInsufficientFunds;
-      ThrowError err
     | True =>
-      (* Subtract amount from 'from' *)
+      (* Subtract amount from from *)
       new_balance = builtin sub bal amount;
       balances_map[from] := new_balance;
       current_total_supply <- total_supply;
@@ -144,11 +177,16 @@ procedure AuthorizedBurnIfSufficientBalance(from: ByStr20, amount: Uint128)
       total_supply := new_total_supply;
       e = {_eventname: "Burnt"; burner: _sender; burn_account: from; amount: amount};
       event e  
-      end
-   end
+    | False =>
+      err = CodeInsufficientFunds;
+      ThrowError err
+    end
+  | None => 
+    err = CodeNoBalance;
+    ThrowError err
+  end
 end
 
-(* Move Tokens if authorized *)
 procedure AuthorizedMoveIfSufficientBalance(from: ByStr20, to: ByStr20, amount: Uint128)
   get_from_bal <- balances_map[from];
   match get_from_bal with
@@ -172,7 +210,7 @@ procedure AuthorizedMoveIfSufficientBalance(from: ByStr20, to: ByStr20, amount: 
       ThrowError err
     end
   | None =>
-    err = CodeNotFound;
+    err = CodeNoBalance;
     ThrowError err
   end
 end
@@ -183,62 +221,44 @@ end
 
 (* Getter transitions *)
 
-(* @dev: Check if an address is an operator or default operator of a token_owner. Provide a Bool *)
-(* @param operator:    Address of a potential operator.                                          *)
-(* @param token_owner: Address of a token_owner.                                                 *)
+(* @dev: Check if an address is an operator or default operator of a token_owner. Throw if not. *)
+(* @param operator:    Address of a potential operator.                                         *)
+(* @param token_owner: Address of a token_owner.                                                *)
 transition IsOperatorFor(token_owner: ByStr20, operator: ByStr20)
-  is_operator_approved <- exists operators_map[token_owner][operator];
-  is_default_operator = is_default_operator f_eq operator default_operators;
-  is_revoked_operator <- exists revoked_default_operators[token_owner][operator];
-  is_default_operator_approved = 
-    let is_not_revoked_operator = negb is_revoked_operator in 
-    andb is_not_revoked_operator is_default_operator;
-  is_approved = orb is_operator_approved is_default_operator_approved;
-  msg_to_sender = { _tag : "IsOperatorForCallBack"; _recipient : _sender; _amount : Uint128 0;
-                    is_operator_for : is_approved};
+  IsApprovedOperator token_owner operator;
+  msg_to_sender = {_tag : "IsOperatorForCallBack"; _recipient : _sender; _amount : zero;
+                    token_owner: token_owner; operator : operator};
   msgs = one_msg msg_to_sender;
   send msgs
 end
 
 (* Optional transitions *)
 
-(* @dev: Optional transition. Mint new tokens. Only contract_owner can mint. *)
+(* @dev: Mint new tokens. Only contract_owner can mint.                      *)
 (* @param recipient: Address of the recipient whose balance is to increase.  *)
 (* @param amount:    Number of tokens to be minted.                          *)
 transition Mint(recipient: ByStr20, amount: Uint128)
-  is_owner = builtin eq _sender contract_owner;
-   match is_owner with
-    | False =>
-      err = CodeNotAuthorized;
-      ThrowError err
-    | True =>
-      AuthorizedMint recipient amount;
-      (* Prevent sending to a contract address that does not support transfers of token *)
-      msg_to_recipient = {_tag : "RecipientAcceptMint"; _recipient : recipient; _amount : zero; 
-                          minter : _sender; recipient : recipient; amount : amount};
-      msg_to_sender = {_tag : "MintSuccessCallBack"; _recipient : _sender; _amount : zero; 
-                          minter : _sender; recipient : recipient; amount : amount};
-      msgs = two_msgs msg_to_recipient msg_to_sender;
-      send msgs
-    end
+  IsOwner _sender;
+  AuthorizedMint recipient amount;
+  (* Prevent sending to a contract address that does not support transfers of token *)
+  msg_to_recipient = {_tag : "RecipientAcceptMint"; _recipient : recipient; _amount : zero; 
+                      minter : _sender; recipient : recipient; amount : amount};
+  msg_to_sender = {_tag : "MintSuccessCallBack"; _recipient : _sender; _amount : zero; 
+                      minter : _sender; recipient : recipient; amount : amount};
+  msgs = two_msgs msg_to_recipient msg_to_sender;
+  send msgs
 end
 
-(* @dev: Optional transition. Burn existing tokens. Only contract_owner can burn. *)
+(* @dev: Burn existing tokens. Only contract_owner can burn.                      *)
 (* @param burn_account: Address of the token_owner whose balance is to decrease.  *)
 (* @param amount:       Number of tokens to be burned.                            *)
 transition Burn(burn_account: ByStr20, amount: Uint128)
-  is_owner = builtin eq _sender contract_owner;
-    match is_owner with
-    | False =>
-      err = CodeNotAuthorized;
-      ThrowError err
-    | True =>
-      AuthorizedBurnIfSufficientBalance burn_account amount;
-      msg_to_sender = {_tag : "BurnSuccessCallBack"; _recipient : _sender; _amount : zero; 
-                        burner : _sender; burn_account : burn_account; amount : amount};
-      msgs = one_msg msg_to_sender;
-      send msgs
-    end
+  IsOwner _sender;
+  AuthorizedBurnIfSufficientBalance burn_account amount;
+  msg_to_sender = {_tag : "BurnSuccessCallBack"; _recipient : _sender; _amount : zero; 
+                    burner : _sender; burn_account : burn_account; amount : amount};
+  msgs = one_msg msg_to_sender;
+  send msgs
 end
 
 (* Compulsory interface transitions *)
@@ -247,108 +267,58 @@ end
 (* @param operator: Address to be authorize as operator or      *)
 (* Re-authorize as default_operator. Cannot be calling address. *)
 transition AuthorizeOperator(operator: ByStr20)
-  is_sender = builtin eq operator _sender;
-  match is_sender with
-  | True => 
-    (* _sender is authorizing self as operator, throw error code *)
-    err = CodeNotAuthorized;
-    ThrowError err
-  | False =>
-    is_default_operator =  is_default_operator f_eq operator default_operators;
-    match is_default_operator with
-    | True =>
-      (* Re-authorize default_operator *)
-      delete revoked_default_operators[_sender][operator];
-      e = { _eventname : "ReAuthorizedDefaultOperatorSuccess"; authorizer : _sender; reauthorized_default_operator : operator};
-      event e
-    | False =>
-      (* Authorize new operator *)
-      authorize = Unit;
-      operators_map[_sender][operator] := authorize;
-      e = {_eventname : "AuthorizeOperatorSuccess"; authorizer : _sender; authorized_operator : operator};
-      event e
-    end
-  end
+  IsNotSender operator;
+  (* Re-authorize default_operator if exists *)
+  delete revoked_default_operators[_sender][operator];
+  (* Authorize new operator if not default_operator *)
+  verdad = Unit;
+  operators_map[_sender][operator] := verdad;
+  e = {_eventname : "AuthorizeOperatorSuccess"; authorizer : _sender; authorized_operator : operator};
+  event e
 end
 
 (* @dev: Revoke an address from being an operator or default_operator of the caller. *)
 (* @param operator: Address to be removed as operator or default_operator.           *)
 transition RevokeOperator(operator: ByStr20)
-  is_default_operator = is_default_operator f_eq operator default_operators;
-  match is_default_operator with
-  | False =>
-    (* Not default_operator, check if operator *)
-    get_operator <- operators_map[_sender][operator];
-    match get_operator with
-    | None =>
-      (* Operator to be removed not found, throw error *)
-      err = CodeNotFound;
-      ThrowError err
-    | Some status =>
-      delete operators_map[_sender][operator];
-      e = {_eventname : "RevokeOperatorSuccess"; revoker : _sender; revoked_operator : operator};
-      event e
-    end
-  | True =>
-    (* Is default_operator, revoke default_operator authority instead *)
-    verdad = Unit;
-    revoked_default_operators[_sender][operator] := verdad;
-    e = {_eventname : "RevokedDefaultOperatorSuccess"; revoker : _sender; revoked_default_operator : operator};
-    event e
-  end
+  IsApprovedOperator _sender operator;
+  (* Remove operator if exists *)
+  delete operators_map[_sender][operator];
+  (* Revoke default_operator if exists *)
+  verdad = Unit;
+  revoked_default_operators[_sender][operator] := verdad;
+  e = {_eventname : "RevokeOperatorSuccess"; revoker : _sender; revoked_operator : operator};
+  event e
 end
 
-(* @dev: Increase the allowance of an approved_spender over the callers tokens. Only token_owner allowed to invoke. *)
+(* @dev: Increase the allowance of an approved_spender over the caller’s tokens. Only token_owner allowed to invoke. *)
 (* param spender:      Address of the designated approved_spender.                                                   *)
 (* param amount:       Number of tokens to be increased as allowance for the approved_spender.                       *)
 transition IncreaseAllowance(spender: ByStr20, amount: Uint128)
-  (* Checks if the _sender and approved_spender is the same *)
-  is_owner = builtin eq _sender spender;
-  match is_owner with
-  | True =>
-    err = CodeNotAuthorized;
-    ThrowError err
-  | False =>
-    get_current_allowance <- allowances_map[_sender][spender];
-    current_allowance =
-      match get_current_allowance with
-      | Some allowance => allowance
-      | None => zero
-      end;
-    new_allowance = builtin add current_allowance amount;
-    allowances_map[_sender][spender] := new_allowance;
-    e = {_eventname : "IncreasedAllowance"; token_owner : _sender; spender: spender; new_allowance : new_allowance};
-    event e
-  end
+  IsNotSender spender;
+  some_current_allowance <- allowances_map[_sender][spender];
+  current_allowance = get_val some_current_allowance;
+  new_allowance = builtin add current_allowance amount;
+  allowances_map[_sender][spender] := new_allowance;
+  e = {_eventname : "IncreasedAllowance"; token_owner : _sender; spender: spender; new_allowance : new_allowance};
+  event e
 end
 
-(* @dev: Decrease the allowance of an approved_spender over the callers tokens. Only token_owner allowed to invoke. *)
+(* @dev: Decrease the allowance of an approved_spender over the caller’s tokens. Only token_owner allowed to invoke. *)
 (* param spender:      Address of the designated approved_spender.                                                   *)
 (* param amount:       Number of tokens to be decreased as allowance for the approved_spender.                       *)
 transition DecreaseAllowance(spender: ByStr20, amount: Uint128)
-  (* Checks if the _sender and approved_spender is the same *)
-  is_owner = builtin eq _sender spender;
-  match is_owner with
-  | True =>
-    err = CodeNotAuthorized;
-    ThrowError err
-  | False =>
-    get_current_allowance <- allowances_map[_sender][spender];
-    current_allowance =
-      match get_current_allowance with
-      | Some allowance => allowance
-      | None => zero
-      end;
-    new_allowance =
-      let amount_le_allowance = uint128_le amount current_allowance in
+  IsNotSender spender;
+  some_current_allowance <- allowances_map[_sender][spender];
+  current_allowance = get_val some_current_allowance;
+  new_allowance =
+    let amount_le_allowance = uint128_le amount current_allowance in
       match amount_le_allowance with
       | True => builtin sub current_allowance amount
       | False => zero
       end;
-    allowances_map[_sender][spender] := new_allowance;
-    e = {_eventname : "DecreasedAllowance"; token_owner : _sender; spender: spender; new_allowance : new_allowance};
-    event e
-  end
+  allowances_map[_sender][spender] := new_allowance;
+  e = {_eventname : "DecreasedAllowance"; token_owner : _sender; spender: spender; new_allowance : new_allowance};
+  event e
 end
 
 (* @dev: Moves an amount tokens from _sender to the recipient. Used by token_owner. *)
@@ -374,28 +344,17 @@ end
 (* @param to:          Address of the recipient whose balance is increased.                             *)
 (* @param amount:      Amount of tokens to be sent.                                                     *)
 transition OperatorSend(from: ByStr20, to: ByStr20, amount: Uint128)
-  is_operator_approved <- exists operators_map[from][_sender];
-  is_default_operator = is_default_operator f_eq _sender default_operators;
-  is_revoked_operator <- exists revoked_default_operators[from][_sender];
-  is_default_operator_approved = let is_not_revoked_operator = 
-    negb is_revoked_operator in andb is_not_revoked_operator is_default_operator;
-  is_approved = orb is_operator_approved is_default_operator_approved;
-  match is_approved with
-    | False =>
-      err = CodeNotAuthorized;
-      ThrowError err
-    | True =>
-      AuthorizedMoveIfSufficientBalance from to amount;
-      e = {_eventname : "OperatorSendSuccess"; initiator : _sender; sender : from; recipient : to; amount : amount};
-      event e;
-      (* Prevent sending to a contract address that does not support transfers of token *)
-      msg_to_recipient = {_tag : "RecipientAcceptOperatorSend"; _recipient : to; _amount : zero; 
-                          initiator : _sender; sender : from; recipient : to; amount : amount};
-      msg_to_sender = {_tag : "OperatorSendSuccessCallBack"; _recipient : _sender; _amount : zero; 
+  IsApprovedOperator from _sender;
+  AuthorizedMoveIfSufficientBalance from to amount;
+  e = {_eventname : "OperatorSendSuccess"; initiator : _sender; sender : from; recipient : to; amount : amount};
+  event e;
+  (* Prevent sending to a contract address that does not support transfers of token *)
+  msg_to_recipient = {_tag : "RecipientAcceptOperatorSend"; _recipient : to; _amount : zero; 
                       initiator : _sender; sender : from; recipient : to; amount : amount};
-      msgs = two_msgs msg_to_recipient msg_to_sender;
-      send msgs
-   end
+  msg_to_sender = {_tag : "OperatorSendSuccessCallBack"; _recipient : _sender; _amount : zero; 
+                  initiator : _sender; sender : from; recipient : to; amount : amount};
+  msgs = two_msgs msg_to_recipient msg_to_sender;
+  send msgs
 end
 
 (* @dev: Move a given amount of tokens from one address to another using the allowance mechanism. The caller must be an approved_spender. *)
@@ -406,15 +365,9 @@ end
 transition TransferFrom(from: ByStr20, to: ByStr20, amount: Uint128)
   get_bal <- balances_map[from];
   match get_bal with
-  | None => 
-    err = CodeNotFound;
-    ThrowError err
   | Some bal =>
     get_spender_allowed <- allowances_map[from][_sender];
     match get_spender_allowed with
-    | None =>
-      err = CodeNotAuthorized;
-      ThrowError err
     | Some allowed =>
       min = min_int bal allowed;
       can_do = uint128_le amount min;
@@ -433,9 +386,15 @@ transition TransferFrom(from: ByStr20, to: ByStr20, amount: Uint128)
         msgs = two_msgs msg_to_recipient msg_to_sender;
         send msgs
       | False =>
-        err = CodeInsufficientFunds;
+        err = CodeInsufficientAllowanceOrFunds;
         ThrowError err
       end
+    | None =>
+      err = CodeNotApprovedSpender;
+      ThrowError err
     end
+  | None => 
+    err = CodeNoBalance;
+    ThrowError err
   end
 end

--- a/reference/FungibleToken.scilla
+++ b/reference/FungibleToken.scilla
@@ -79,7 +79,8 @@ let get_val =
 (***************************************************)
 
 contract FungibleToken
-(contract_owner: ByStr20,
+(
+  contract_owner: ByStr20,
   name : String,
   symbol: String,
   decimals: Uint32,
@@ -93,7 +94,7 @@ field total_supply : Uint128 = init_supply
 
 field balances_map: Map ByStr20 Uint128 
   = let emp_map = Emp ByStr20 Uint128 in
-  builtin put emp_map contract_owner init_supply
+    builtin put emp_map contract_owner init_supply
 
 field operators_map: Map ByStr20 (Map ByStr20 Unit) 
   = Emp ByStr20 (Map ByStr20 Unit)
@@ -108,7 +109,6 @@ field allowances_map: Map ByStr20 (Map ByStr20 Uint128)
 (*             Procedures             *)
 (**************************************)
 
-(* Emit Errors *)
 procedure ThrowError(err : Error)
   e = make_error err;
   throw e
@@ -194,10 +194,10 @@ procedure AuthorizedMoveIfSufficientBalance(from: ByStr20, to: ByStr20, amount: 
     can_do = uint128_le amount bal;
     match can_do with
     | True =>
-      (* Subtract amount from "from" and add it to "to" address *)
+      (* Subtract amount from from and add it to to address *)
       new_from_bal = builtin sub bal amount;
       balances_map[from] := new_from_bal;
-      (* Adds amount to "to" address *)
+      (* Adds amount to to address *)
       get_to_bal <- balances_map[to];
       new_to_bal = match get_to_bal with
       | Some bal => builtin add bal amount
@@ -290,7 +290,7 @@ transition RevokeOperator(operator: ByStr20)
   event e
 end
 
-(* @dev: Increase the allowance of an approved_spender over the caller’s tokens. Only token_owner allowed to invoke. *)
+(* @dev: Increase the allowance of an approved_spender over the caller tokens. Only token_owner allowed to invoke.   *)
 (* param spender:      Address of the designated approved_spender.                                                   *)
 (* param amount:       Number of tokens to be increased as allowance for the approved_spender.                       *)
 transition IncreaseAllowance(spender: ByStr20, amount: Uint128)
@@ -303,9 +303,9 @@ transition IncreaseAllowance(spender: ByStr20, amount: Uint128)
   event e
 end
 
-(* @dev: Decrease the allowance of an approved_spender over the caller’s tokens. Only token_owner allowed to invoke. *)
-(* param spender:      Address of the designated approved_spender.                                                   *)
-(* param amount:       Number of tokens to be decreased as allowance for the approved_spender.                       *)
+(* @dev: Decrease the allowance of an approved_spender over the caller tokens. Only token_owner allowed to invoke. *)
+(* param spender:      Address of the designated approved_spender.                                                 *)
+(* param amount:       Number of tokens to be decreased as allowance for the approved_spender.                     *)
 transition DecreaseAllowance(spender: ByStr20, amount: Uint128)
   IsNotSender spender;
   some_current_allowance <- allowances_map[_sender][spender];

--- a/zrcs/zrc-0.md
+++ b/zrcs/zrc-0.md
@@ -180,6 +180,8 @@ The current ZRC editors are
 
 - Amrit Kumar ([**@AmritKumar**](https://github.com/AmritKumar))
 
+- Arnav Vohra ([**@arnavvohra**](https://github.com/arnavvohra))
+
 
 ## ZRC Editor Responsibilities
 

--- a/zrcs/zrc-2.md
+++ b/zrcs/zrc-2.md
@@ -270,7 +270,7 @@ transition Transfer(to: ByStr20, amount: Uint128)
 
 |              | Name       | Description                | Event Parameters                                                                                                                                                                                      |
 | ------------ | ---------- | -------------------------- | ----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
-| `_eventname` | `Transfer` | Sending is successful.     | `sender`: `ByStr20` which is the sender's address, `recipient`: `ByStr20` which is the recipient's address, and `amount`: `Uint128` which is the amount of fungible tokens transferred.               |
+| `_eventname` | `TransferSuccess` | Sending is successful.     | `sender`: `ByStr20` which is the sender's address, `recipient`: `ByStr20` which is the recipient's address, and `amount`: `Uint128` which is the amount of fungible tokens transferred.               |
 | `_eventname` | `Error`    | Sending is not successful. | - emit `CodeNoBalance` if the balance of token_owner is not found. <br> - emit `CodeInsufficientFunds` if the balance of the token_owner lesser than the specified amount that was to be transferred. |
 
 #### 8. OperatorSend()

--- a/zrcs/zrc-2.md
+++ b/zrcs/zrc-2.md
@@ -1,6 +1,6 @@
 | ZRC | Title                        | Status   | Type     | Author                                                                                                                       | Created (yyyy-mm-dd) | Updated (yyyy-mm-dd) |
 | --- | ---------------------------- | -------- | -------- | ---------------------------------------------------------------------------------------------------------------------------- | -------------------- | -------------------- |
-| 1   | Standard for Fungible Tokens | Approved | Standard | Gareth Mensah <gareth@zilliqa.com> <br> Vaivaswatha Nagaraj <vaivaswatha@zilliqa.com> <br> Chua Han Wen <hanwen@zilliqa.com> | 2019-11-18           | 2020-02-12           |
+| 2   | Standard for Fungible Tokens | Approved | Standard | Vaivaswatha Nagaraj <vaivaswatha@zilliqa.com> <br> Chua Han Wen <hanwen@zilliqa.com> | 2019-11-18           | 2020-04-25           |
 
 ## I. What are Fungible Tokens?
 

--- a/zrcs/zrc-2.md
+++ b/zrcs/zrc-2.md
@@ -97,7 +97,7 @@ transition IsOperatorFor(token_owner: ByStr20, operator: ByStr20)
 #### 1. Mint() (Optional)
 
 ```ocaml
-(* @dev: Optional transition. Mint new tokens. Only contract_owner can mint. *)
+(* @dev: Mint new tokens. Only contract_owner can mint.                      *)
 (* @param recipient: Address of the recipient whose balance is to increase.  *)
 (* @param amount:    Number of tokens to be minted.                          *)
 transition Mint(recipient: ByStr20, amount: Uint128)
@@ -127,7 +127,7 @@ transition Mint(recipient: ByStr20, amount: Uint128)
 #### 2. Burn() (Optional)
 
 ```ocaml
-(* @dev: Optional transition. Burn existing tokens. Only contract_owner can burn. *)
+(* @dev: Burn existing tokens. Only contract_owner can burn.                      *)
 (* @param burn_account: Address of the token_owner whose balance is to decrease.  *)
 (* @param amount:       Number of tokens to be burned.                            *)
 transition Burn(burn_account: ByStr20, amount: Uint128)
@@ -199,7 +199,7 @@ transition RevokeOperator(operator: ByStr20)
 #### 5. IncreaseAllowance()
 
 ```ocaml
-(* @dev: Increase the allowance of an approved_spender over the caller’s tokens. Only token_owner allowed to invoke. *)
+(* @dev: Increase the allowance of an approved_spender over the caller tokens. Only token_owner allowed to invoke.   *)
 (* param spender:      Address of the designated approved_spender.                                                   *)
 (* param amount:       Number of tokens to be increased as allowance for the approved_spender.                       *)
 transition IncreaseAllowance(spender: ByStr20, amount: Uint128)
@@ -222,9 +222,9 @@ transition IncreaseAllowance(spender: ByStr20, amount: Uint128)
 #### 6. DecreaseAllowance()
 
 ```ocaml
-(* @dev: Decrease the allowance of an approved_spender over the caller’s tokens. Only token_owner allowed to invoke. *)
-(* param spender:      Address of the designated approved_spender.                                                   *)
-(* param amount:       Number of tokens to be decreased as allowance for the approved_spender.                       *)
+(* @dev: Decrease the allowance of an approved_spender over the caller tokens. Only token_owner allowed to invoke. *)
+(* param spender:      Address of the designated approved_spender.                                                 *)
+(* param amount:       Number of tokens to be decreased as allowance for the approved_spender.                     *)
 transition DecreaseAllowance(spender: ByStr20, amount: Uint128)
 ```
 

--- a/zrcs/zrc-2.md
+++ b/zrcs/zrc-2.md
@@ -1,6 +1,6 @@
-| ZRC | Title                        | Status | Type  | Author                                                                                                                       | Created (yyyy-mm-dd) | Updated (yyyy-mm-dd) |
-| --- | ---------------------------- | ------ | ----- | ---------------------------------------------------------------------------------------------------------------------------- | -------------------- | -------------------- |
-| 1   | Standard for Fungible Tokens | Approved  | Standard | Gareth Mensah <gareth@zilliqa.com> <br> Vaivaswatha Nagaraj <vaivaswatha@zilliqa.com> <br> Chua Han Wen <hanwen@zilliqa.com> | 2019-11-18           | 2020-02-12           |
+| ZRC | Title                        | Status   | Type     | Author                                                                                                                       | Created (yyyy-mm-dd) | Updated (yyyy-mm-dd) |
+| --- | ---------------------------- | -------- | -------- | ---------------------------------------------------------------------------------------------------------------------------- | -------------------- | -------------------- |
+| 1   | Standard for Fungible Tokens | Approved | Standard | Gareth Mensah <gareth@zilliqa.com> <br> Vaivaswatha Nagaraj <vaivaswatha@zilliqa.com> <br> Chua Han Wen <hanwen@zilliqa.com> | 2019-11-18           | 2020-02-12           |
 
 ## I. What are Fungible Tokens?
 
@@ -35,13 +35,17 @@ The fungible token contract specification describes:
 
 ### B. Error Codes
 
-The fungible token contract must define the following constants for use as error codes for the `Error` event.
+The fungible token contract must define the following constants for use as error codes for the `Error` exception.
 
-| Name                    | Type    | Code | Description                                                       |
-| ----------------------- | ------- | ---- | ----------------------------------------------------------------- |
-| `CodeNotAuthorized`     | `Int32` | `-1` | Emit when the transition call is unauthorised for a given user.   |
-| `CodeNotFound`          | `Int32` | `-2` | Emit when a requested value is missing.                           |
-| `CodeInsufficientFunds` | `Int32` | `-3` | Emit when there is insufficient balance to authorise transaction. |
+| Name                               | Type    | Code | Description                                                                    |
+| ---------------------------------- | ------- | ---- | ------------------------------------------------------------------------------ |
+| `CodeNotOwner`                     | `Int32` | `-1` | Emit when the sender is not contract_owner.                                    |
+| `CodeIsSender`                     | `Int32` | `-2` | Emit when an address is same as is the sender.                                 |
+| `CodeNotApprovedOperator`          | `Int32` | `-3` | Emit when caller is not an approved operator or default_operator.              |
+| `CodeNotApprovedSpender`           | `Int32` | `-4` | Emit when caller is not an approved_spender.                                   |
+| `CodeNoBalance`                    | `Int32` | `-5` | Emit when there is no balance to authorise transaction.                        |
+| `CodeInsufficientFunds`            | `Int32` | `-6` | Emit when there is insufficient balance to authorise transaction.              |
+| `CodeInsufficientAllowanceOrFunds` | `Int32` | `-7` | Emit when there is insufficient balance or allowance to authorise transaction. |
 
 ### C. Immutable Variables
 
@@ -69,9 +73,9 @@ The fungible token contract must define the following constants for use as error
 #### 1. IsOperatorFor()
 
 ```ocaml
-(* @dev: Check if an address is an operator or default operator of a token_owner. Provide a Bool *)
-(* @param operator:    Address of a potential operator.                                          *)
-(* @param token_owner: Address of a token_owner.                                                 *)
+(* @dev: Check if an address is an operator or default operator of a token_owner. Throw if not. *)
+(* @param operator:    Address of a potential operator.                                         *)
+(* @param token_owner: Address of a token_owner.                                                *)
 transition IsOperatorFor(token_owner: ByStr20, operator: ByStr20)
 ```
 
@@ -84,9 +88,9 @@ transition IsOperatorFor(token_owner: ByStr20, operator: ByStr20)
 
 **Messages sent:**
 
-|        | Name                    | Description                                                                                                                                             | Callback Parameters                                                                                                            |
-| ------ | ----------------------- | ------------------------------------------------------------------------------------------------------------------------------------------------------- | ------------------------------------------------------------------------------------------------------------------------------ |
-| `_tag` | `IsOperatorForCallBack` | Provide the sender a True or False statement depending on whether the operator address is indeed the an approved operator of the specified token_owner. | `is_operator_for` of type `Bool` representing the status of the operator as an approved operator of the specified token_owner. |
+|        | Name                    | Description                                                                                                 | Callback Parameters                                                                                                                                          |
+| ------ | ----------------------- | ----------------------------------------------------------------------------------------------------------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------ |
+| `_tag` | `IsOperatorForCallBack` | Provide the sender a callback if specified address is indeed an approved operator of specified token_owner. | `token_owner` : `ByStr20`, `operator`: `ByStr20`, where `token_owner` is the address of the token_owner, `operator` is the address of the approved operator. |
 
 ### F. Interface Transitions
 
@@ -118,7 +122,7 @@ transition Mint(recipient: ByStr20, amount: Uint128)
 |              | Name     | Description                | Event Parameters                                                                                                                                                                                                                  |
 | ------------ | -------- | -------------------------- | --------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
 | `_eventname` | `Minted` | Minting is successful.     | `minter` : `ByStr20`, `recipient`: `ByStr20`, `amount`: `Uint128`, where `minter` is the address of the minter, `recipient` is the address whose balance will be increased, and `amount` is the amount of fungible tokens minted. |
-| `_eventname` | `Error`  | Minting is not successful. | - emit `CodeNotAuthorized` if the transition is not called by the contract_owner.                                                                                                                                                 |
+| `_eventname` | `Error`  | Minting is not successful. | - emit `CodeNotOwner` if the transition is not called by the contract_owner.                                                                                                                                                      |
 
 #### 2. Burn() (Optional)
 
@@ -144,10 +148,10 @@ transition Burn(burn_account: ByStr20, amount: Uint128)
 
 **Events:**
 
-|              | Name    | Description                | Event Parameters                                                                                                                                                                                                                        |
-| ------------ | ------- | -------------------------- | --------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
-| `_eventname` | `Burnt` | Burning is successful.     | `burner` : `ByStr20`, `burn_account`: `ByStr20`, `amount`: `Uint128`, where `burner` is the address of the burner, `burn_account` is the address whose balance will be decreased, and `amount` is the amount of fungible tokens burned. |
-| `_eventname` | `Error` | Burning is not successful. | - emit `CodeNotAuthorized` if the transition is not called by the contract_owner. <br> - emit `CodeInsufficientFunds` if the amount to be burned is more than the balance of the token_owner.                                           |
+|              | Name    | Description                | Event Parameters                                                                                                                                                                                                                                                |
+| ------------ | ------- | -------------------------- | --------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| `_eventname` | `Burnt` | Burning is successful.     | `burner` : `ByStr20`, `burn_account`: `ByStr20`, `amount`: `Uint128`, where `burner` is the address of the burner, `burn_account` is the address whose balance will be decreased, and `amount` is the amount of fungible tokens burned.                         |
+| `_eventname` | `Error` | Burning is not successful. | - emit `CodeNotOwner` if the transition is not called by the contract_owner. <br> - emit `CodeNoBalance` if balance of token_owner does not exists. <br> - emit `CodeInsufficientFunds` if the amount to be burned is more than the balance of the token_owner. |
 
 #### 3. AuthorizeOperator()
 
@@ -166,11 +170,10 @@ transition AuthorizeOperator(operator: ByStr20)
 
 **Events:**
 
-|              | Name                                 | Description                    | Event Parameters                                                                                                                                                                          |
-| ------------ | ------------------------------------ | ------------------------------ | ----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
-| `_eventname` | `AuthorizeOperatorSuccess`           | Authorizing is successful.     | `authorizer`: `ByStr20` which is the caller's address, and `authorized_operator`: `ByStr20` which is the address to be authorized as an operator of the token_owner.                      |
-| `_eventname` | `ReAuthorizedDefaultOperatorSuccess` | Authorizing is successful.     | `authorizer`: `ByStr20` which is the caller's address., and `reauthorized_default_operator`: `ByStr20` which is the address to be re-authorized as a default_operator of the token_owner. |
-| `_eventname` | `Error`                              | Authorizing is not successful. | - emit `CodeNotAuthorized` if the user is trying to authorize himself as an operator.                                                                                                     |
+|              | Name                       | Description                    | Event Parameters                                                                                                                                                     |
+| ------------ | -------------------------- | ------------------------------ | -------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| `_eventname` | `AuthorizeOperatorSuccess` | Authorizing is successful.     | `authorizer`: `ByStr20` which is the caller's address, and `authorized_operator`: `ByStr20` which is the address to be authorized as an operator of the token_owner. |
+| `_eventname` | `Error`                    | Authorizing is not successful. | - emit `CodeIsSender` if the user is trying to authorize himself as an operator.                                                                                     |
 
 #### 4. RevokeOperator()
 
@@ -188,11 +191,10 @@ transition RevokeOperator(operator: ByStr20)
 
 **Events:**
 
-|              | Name                            | Description                 | Event Parameters                                                                                                                                                                 |
-| ------------ | ------------------------------- | --------------------------- | -------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
-| `_eventname` | `RevokeOperatorSuccess`         | Revoking is successful.     | `revoker`: `ByStr20` which is the caller's address, and `revoked_operator`: `ByStr20` which is the address to be removed as an operator of the token_owner.                      |
-| `_eventname` | `RevokedDefaultOperatorSuccess` | Revoking is successful.     | `revoker`: `ByStr20` which is the caller's address, and `revoked_default_operator`: `ByStr20` which is the address to be removed as a default_operator of the token_owner.       |
-| `_eventname` | `Error`                         | Revoking is not successful. | - emit `CodeNotAuthorized` if the user is trying to authorize himself as an operator. <br> - emit `CodeNotFound` if the specified address is not an operator of the token_owner. |
+|              | Name                    | Description                 | Event Parameters                                                                                                                                            |
+| ------------ | ----------------------- | --------------------------- | ----------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| `_eventname` | `RevokeOperatorSuccess` | Revoking is successful.     | `revoker`: `ByStr20` which is the caller's address, and `revoked_operator`: `ByStr20` which is the address to be removed as an operator of the token_owner. |
+| `_eventname` | `Error`                 | Revoking is not successful. | - emit `CodeNotApprovedOperator` if the specified address is not an existing operator or default_operator of the token_owner.                               |
 
 #### 5. IncreaseAllowance()
 
@@ -215,7 +217,7 @@ transition IncreaseAllowance(spender: ByStr20, amount: Uint128)
 |              | Name                 | Description                                                   | Event Parameters                                                                                                                                                                                                                                  |
 | ------------ | -------------------- | ------------------------------------------------------------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
 | `_eventname` | `IncreasedAllowance` | Increasing of allowance of an approved_spender is successful. | `token_owner`: `ByStr20` which is the address the token_owner, `spender`: `ByStr20` which is the address of a approved_spender of the token_owner, and `new_allowance` is the new spending allowance of the approved_spender for the token_owner. |
-| `_eventname` | `Error`              | Increasing of allowance is not successful.                    | - emit `CodeNotAuthorized` if the user is trying to authorize himself as an approved_spender.                                                                                                                                                     |
+| `_eventname` | `Error`              | Increasing of allowance is not successful.                    | - emit `CodeIsSelf` if the user is trying to authorize himself as an approved_spender.                                                                                                                                                            |
 
 #### 6. DecreaseAllowance()
 
@@ -238,7 +240,7 @@ transition DecreaseAllowance(spender: ByStr20, amount: Uint128)
 |              | Name                 | Description                                                   | Event Parameters                                                                                                                                                                                                                                  |
 | ------------ | -------------------- | ------------------------------------------------------------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
 | `_eventname` | `DecreasedAllowance` | Decreasing of allowance of an approved_spender is successful. | `token_owner`: `ByStr20` which is the address the token_owner, `spender`: `ByStr20` which is the address of a approved_spender of the token_owner, and `new_allowance` is the new spending allowance of the approved_spender for the token_owner. |
-| `_eventname` | `Error`              | Decreasing of allowance is not successful.                    | - emit `CodeNotAuthorized` if the user is trying to authorize himself as an approved_spender.                                                                                                                                                     |
+| `_eventname` | `Error`              | Decreasing of allowance is not successful.                    | - emit `CodeIsSelf` if the user is trying to authorize himself as an approved_spender.                                                                                                                                                            |
 
 #### 7. Transfer()
 
@@ -266,10 +268,10 @@ transition Transfer(to: ByStr20, amount: Uint128)
 
 **Events:**
 
-|              | Name       | Description                | Event Parameters                                                                                                                                                                        |
-| ------------ | ---------- | -------------------------- | --------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
-| `_eventname` | `Transfer` | Sending is successful.     | `sender`: `ByStr20` which is the sender's address, `recipient`: `ByStr20` which is the recipient's address, and `amount`: `Uint128` which is the amount of fungible tokens transferred. |
-| `_eventname` | `Error`    | Sending is not successful. | - emit `CodeNotFound` if the balance is not found. <br> - emit `CodeInsufficientFunds` if the balance of the token_owner is insufficient.                                               |
+|              | Name       | Description                | Event Parameters                                                                                                                                                                                      |
+| ------------ | ---------- | -------------------------- | ----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| `_eventname` | `Transfer` | Sending is successful.     | `sender`: `ByStr20` which is the sender's address, `recipient`: `ByStr20` which is the recipient's address, and `amount`: `Uint128` which is the amount of fungible tokens transferred.               |
+| `_eventname` | `Error`    | Sending is not successful. | - emit `CodeNoBalance` if the balance of token_owner is not found. <br> - emit `CodeInsufficientFunds` if the balance of the token_owner lesser than the specified amount that was to be transferred. |
 
 #### 8. OperatorSend()
 
@@ -299,10 +301,10 @@ transition OperatorSend(from: ByStr20, to: ByStr20, amount: Uint128)
 
 **Events:**
 
-|              | Name                  | Description                | Event Parameters                                                                                                                                                                                                                                           |
-| ------------ | --------------------- | -------------------------- | ---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
-| `_eventname` | `OperatorSendSuccess` | Sending is successful.     | `initiator`: `ByStr20` which is the operator's address, `sender`: `ByStr20` which is the token_owner's address, `recipient`: `ByStr20` which is the recipient's address, and `amount`: `Uint128` which is the amount of fungible tokens to be transferred. |
-| `_eventname` | `Error`               | Sending is not successful. | - emit `CodeNotAuthorized` if sender is not an operator for the token_owner <br> emit `CodeNotFound` if the balance is not found. <br> - emit `CodeInsufficientFunds` if the balance of the token_owner is insufficient.                                   |
+|              | Name                  | Description                | Event Parameters                                                                                                                                                                                                                                                                                       |
+| ------------ | --------------------- | -------------------------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------ |
+| `_eventname` | `OperatorSendSuccess` | Sending is successful.     | `initiator`: `ByStr20` which is the operator's address, `sender`: `ByStr20` which is the token_owner's address, `recipient`: `ByStr20` which is the recipient's address, and `amount`: `Uint128` which is the amount of fungible tokens to be transferred.                                             |
+| `_eventname` | `Error`               | Sending is not successful. | - emit `CodeNotApprovedOperator` if sender is not an approved operator for the token_owner <br> emit `CodeNoBalance` if the balance of token_owner is not found. <br> - emit `CodeInsufficientFunds` if the balance of the token_owner is lesser than the specified amount that was to be transferred. |
 
 #### 9. TransferFrom()
 
@@ -332,19 +334,19 @@ transition TransferFrom(from: ByStr20, to: ByStr20, amount: Uint128)
 
 **Events:**
 
-|              | Name                  | Description                | Event Parameters                                                                                                                                                                                                                                                                                             |
-| ------------ | --------------------- | -------------------------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------ |
-| `_eventname` | `TransferFromSuccess` | Sending is successful.     | `initiator`: `ByStr20`, `sender` : `ByStr20`, `recipient`: `ByStr20`, `amount`: `Uint128`, where `initiator` is the address of an approved_spender,`sender` is the address of the token_owner, `recipient` is the address of the recipient, and `amount` is the amount of fungible tokens to be transferred. |
-| `_eventname` | `Error`               | Sending is not successful. | - emit `CodeNotAuthorized` if sender is not an approved_spender for the token_owner <br> emit `CodeNotFound` if the balance is not found. <br> - emit `CodeInsufficientFunds` if the balance of the token_owner or the allowance of the approved_spender is insufficient.                                    |
+|              | Name                  | Description                | Event Parameters                                                                                                                                                                                                                                                                                                                         |
+| ------------ | --------------------- | -------------------------- | ---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| `_eventname` | `TransferFromSuccess` | Sending is successful.     | `initiator`: `ByStr20`, `sender` : `ByStr20`, `recipient`: `ByStr20`, `amount`: `Uint128`, where `initiator` is the address of an approved_spender,`sender` is the address of the token_owner, `recipient` is the address of the recipient, and `amount` is the amount of fungible tokens to be transferred.                             |
+| `_eventname` | `Error`               | Sending is not successful. | - emit `CodeNotApprovedSpender` if sender is not an approved_spender for the token_owner <br> emit `CodeNoBalance` if the balance of token_owner is not found. <br> - emit `CodeInsufficientAllowanceOrFunds` if the allowance of operator or balance of the token_owner is lesser than the specified amount that was to be transferred. |
 
 ## V. Existing Implementation(s)
 
 - [Fungible Token Reference contract](../reference/FungibleToken.scilla)
 
-To test the reference contract, simply go to the [`example/zrc2`](../example/zrc2) folder and run one of the JS scripts. For example, to deploy the contract, run:
+To test the reference contract, simply go to the [`example`](../example) folder and run one of the JS scripts. For example, to deploy the contract, run:
 
 ```shell
-yarn deploy
+yarn deploy.js
 ```
 
 > **NOTE:** Please change the `privkey` in the script to your own private key. You can generate a testnet wallet and request for testnet \$ZIL at the [Nucleus Faucet](https://dev-wallet.zilliqa.com/home).


### PR DESCRIPTION
There was an inconsistency between the names of the event used in the Transfer transition and TransferFrom transition. As discussed with @evesnow91 , we will update the event name of the Transfer transition to match that of the TransferFrom transition.