### PR TITLE
ZRC-5: Convention for Deposit of ZIL

### DIFF
--- a/zrcs/zrc-5.md
+++ b/zrcs/zrc-5.md
@@ -16,7 +16,7 @@ For a smart contract to accept incoming ZIL, it needs to do so explicitly using 
 
 However, there is currently no naming convention for transition that can accept ZIL. As a result, cryptocurrency exchange or cryptocurrency wallet provider does not know which `_tag` to set, should it wishes to transfer ZIL to a contract address. 
 
-By having a naming convention for transition that can accept ZIL, one can easily transfer ZIL to a contract that follows this convention, thereby improving composability. 
+By having a naming convention for transitions that can accept ZIL, one can easily transfer ZIL to a contract that follows this convention, thereby improving composability. 
 
 ## IV. Specification
 

--- a/zrcs/zrc-5.md
+++ b/zrcs/zrc-5.md
@@ -14,7 +14,7 @@ ZRC-5 defines a convention for an interface that a smart contract should impleme
 
 For a smart contract to accept incoming ZIL, it needs to do so explicitly using the `accept` statement. As such, any transition that does not have the `accept` statement  will not be able to accept any incoming ZIL transfer. 
 
-However, there is currently no naming convention for transition that can accept ZIL. As a result, cryptocurrency exchange or cryptocurrency wallet provider does not know which `_tag` to set, should it wishes to transfer ZIL to a contract address. 
+However, there is currently no naming convention for transitions that can accept ZIL. As a result, cryptocurrency exchanges or cryptocurrency wallet providers do not know which `_tag` to set, should they wish to transfer ZIL to a contract address. 
 
 By having a naming convention for transitions that can accept ZIL, one can easily transfer ZIL to a contract that follows this convention, thereby improving composability. 
 

--- a/zrcs/zrc-5.md
+++ b/zrcs/zrc-5.md
@@ -35,7 +35,7 @@ Within the `AddFunds` transition, there should be an `accept` instruction.
 
 ### C. Conditional acceptance of ZIL
 
-Smart contract developers are free to introduce any programmatic logic to conditionally accept ZIL in `AddFunds` transition. Smart contract developers can also use `accept` instruction in other transition, however, for such transition will reduce composability of the smart contract. 
+Smart contract developers are free to introduce any programmatic logic to conditionally accept ZIL in `AddFunds` transition. Smart contract developers can also use `accept` instruction in other transitions, however, such transitions may reduce composability of the smart contract. 
 
 ### D. Sample implementation
 This is a sample implementation of `AddFunds` transition that unconditionally accepts ZIL.

--- a/zrcs/zrc-5.md
+++ b/zrcs/zrc-5.md
@@ -50,7 +50,7 @@ end
 
 - [MultiSig Wallet Reference contract](../reference/multisig_wallet.scilla#L406)
 
-To test the reference contract, simply go to the [`example/zrc4`](../example/zrc4) folder and run `add_funds.js`.
+To test the reference contract, simply go to the [`example/zrc4`](../example/zrc4) folder and run `node add_funds.js`.
 
 ## VI. Copyright
 

--- a/zrcs/zrc-5.md
+++ b/zrcs/zrc-5.md
@@ -27,7 +27,7 @@ The deposit of ZIL specification describes:
 
 ### A. Naming of transition
 
-For a contract that wishes to conditionally or unconditionally accept ZIL, it should implement a transition named `AddFumds`.
+For a contract that wishes to conditionally or unconditionally accept ZIL, it should implement a transition named `AddFunds`.
 
 ### B. Mandatory instruction 
 

--- a/zrcs/zrc-5.md
+++ b/zrcs/zrc-5.md
@@ -12,7 +12,7 @@ ZRC-5 defines a convention for an interface that a smart contract should impleme
 
 ## III. Motivation
 
-For a smart contract to accept incoming ZIL, smart contract development needs to explicitly `accept` the ZIL using`accept` instruction. As such, any transition that does not have `accept` instruction will not be able to accept any incoming ZIL transfer. 
+For a smart contract to accept incoming ZIL, it needs to do so explicitly using the `accept` statement. As such, any transition that does not have the `accept` statement  will not be able to accept any incoming ZIL transfer. 
 
 However, there is currently no naming convention for transition that can accept ZIL. As a result, cryptocurrency exchange or cryptocurrency wallet provider does not know which `_tag` to set, should it wishes to transfer ZIL to a contract address. 
 

--- a/zrcs/zrc-5.md
+++ b/zrcs/zrc-5.md
@@ -1,0 +1,57 @@
+| ZRC | Title                        | Status   | Type     | Author                                                                                                                       | Created (yyyy-mm-dd) | Updated (yyyy-mm-dd) |
+| --- | ---------------------------- | -------- | -------- | ---------------------------------------------------------------------------------------------------------------------------- | -------------------- | -------------------- |
+| 5   | Convention for Deposit of ZIL | Draft | Standard | Jun Hao Tan <junhao@zilliqa.com> | 2020-06-25           | 2020-06-25           |
+
+## I. What is ZIL?
+
+ZIL is the native token for [Zilliqa](https://www.zilliqa.com/) blockchain. One can store ZIL inside any Zilliqa address, including smart contract address.
+
+## II. Abstract
+
+ZRC-5 defines a convention for an interface that a smart contract should implement should it decide to accept ZIL.
+
+## III. Motivation
+
+For a smart contract to accept incoming ZIL, smart contract development needs to explicitly `accept` the ZIL using`accept` instruction. As such, any transition that does not have `accept` instruction will not be able to accept any incoming ZIL transfer. 
+
+However, there is currently no naming convention for transition that can accept ZIL. As a result, cryptocurrency exchange or cryptocurrency wallet provider does not know which `_tag` to set, should it wishes to transfer ZIL to a contract address. 
+
+By having a naming convention for transition that can accept ZIL, one can easily transfer ZIL to a contract that follows this convention, thereby improving composability. 
+
+## IV. Specification
+
+The deposit of ZIL specification describes:
+
+1. the naming convention of the transition
+2. mandatory instruction in the transition
+
+### A. Naming of transition
+
+For a contract that wishes to conditionally or unconditionally accept ZIL, it should implement a transition named `AddFumds`.
+
+### B. Mandatory instruction 
+
+Within the `AddFunds` transition, there should be an `accept` instruction. 
+
+### C. Conditional acceptance of ZIL
+
+Smart contract developers are free to introduce any programmatic logic to conditionally accept ZIL in `AddFunds` transition. Smart contract developers can also use `accept` instruction in other transition, however, for such transition will reduce composability of the smart contract. 
+
+### D. Sample implementation
+This is a sample implementation of `AddFunds` transition that unconditionally accepts ZIL.
+
+```
+transition AddFunds ()
+  accept;
+end
+```
+
+## V. Existing Implementation(s)
+
+- [MultiSig Wallet Reference contract](../reference/multisig_wallet.scilla#L406)
+
+To test the reference contract, simply go to the [`example/zrc4`](../example/zrc4) folder and run `add_funds.js`.
+
+## VI. Copyright
+
+Copyright and related rights waived via [CC0](https://creativecommons.org/publicdomain/zero/1.0/).

--- a/zrcs/zrc-5.md
+++ b/zrcs/zrc-5.md
@@ -27,7 +27,7 @@ The deposit of ZIL specification describes:
 
 ### A. Naming of transition
 
-For a contract that wishes to conditionally or unconditionally accept ZIL, it should implement a transition named `AddFunds`.
+For a contract that wishes to conditionally or unconditionally accept ZIL, it should implement a transition named `AddFunds` that does not take any parameters.
 
 ### B. Mandatory instruction 
 


### PR DESCRIPTION
This PR introduces ZRC-5, which standardize the naming convention `AddFunds` transition