### PR TITLE
fix(zrc-2): Make operator and default_operator roles optional

### DIFF
--- a/example/zrc2/deploy.js
+++ b/example/zrc2/deploy.js
@@ -20,7 +20,7 @@ async function main() {
     const myGasPrice = units.toQa('1000', units.Units.Li); // Gas Price that will be used by all transactions
 
     console.log("start to deploy zrc2: ");
-    const code = fs.readFileSync("../../reference/FungibleToken.scilla").toString();
+    const code = fs.readFileSync("../../reference/FungibleToken-Operator.scilla").toString();
     console.log("contract code is: ");
     console.log(code);
     const init = [

--- a/reference/FungibleToken-Mintable.scilla
+++ b/reference/FungibleToken-Mintable.scilla
@@ -22,6 +22,7 @@ type Error =
 | CodeIsSender
 | CodeInsufficientFunds
 | CodeInsufficientAllowance
+| CodeNotOwner
 
 let make_error =
   fun (result : Error) =>
@@ -30,6 +31,7 @@ let make_error =
       | CodeIsSender              => Int32 -1
       | CodeInsufficientFunds     => Int32 -2
       | CodeInsufficientAllowance => Int32 -3
+      | CodeNotOwner              => Int32 -4
       end
     in
     { _exception : "Error"; code : result_code }
@@ -80,6 +82,16 @@ procedure ThrowError(err : Error)
   throw e
 end
 
+procedure IsOwner(address: ByStr20)
+  is_owner = builtin eq contract_owner address;
+  match is_owner with
+  | True =>
+  | False =>
+    err = CodeNotOwner;
+    ThrowError err
+  end
+end
+
 procedure IsNotSender(address: ByStr20)
   is_sender = builtin eq _sender address;
   match is_sender with
@@ -87,6 +99,43 @@ procedure IsNotSender(address: ByStr20)
     err = CodeIsSender;
     ThrowError err
   | False =>
+  end
+end
+
+procedure AuthorizedMint(recipient: ByStr20, amount: Uint128) 
+  some_bal <- balances[recipient];
+  bal = get_val some_bal;
+  new_balance = builtin add amount bal;
+  balances[recipient] := new_balance;
+  current_total_supply <- total_supply;
+  new_total_supply = builtin add current_total_supply amount;
+  total_supply := new_total_supply;
+  e = {_eventname: "Minted"; minter: _sender; recipient: recipient; amount: amount};
+  event e
+end
+
+procedure AuthorizedBurnIfSufficientBalance(from: ByStr20, amount: Uint128)
+  get_bal <- balances[from];
+  match get_bal with
+  | Some bal =>
+    can_burn = uint128_le amount bal;
+    match can_burn with
+    | True =>
+      (* Subtract amount from from *)
+      new_balance = builtin sub bal amount;
+      balances[from] := new_balance;
+      current_total_supply <- total_supply;
+      new_total_supply = builtin sub current_total_supply amount;
+      total_supply := new_total_supply;
+      e = {_eventname: "Burnt"; burner: _sender; burn_account: from; amount: amount};
+      event e  
+    | False =>
+      err = CodeInsufficientFunds;
+      ThrowError err
+    end
+  | None => 
+    err = CodeInsufficientFunds;
+    ThrowError err
   end
 end
 
@@ -121,6 +170,33 @@ end
 (***************************************)
 (*             Transitions             *)
 (***************************************)
+
+(* @dev: Mint new tokens. Only contract_owner can mint.                      *)
+(* @param recipient: Address of the recipient whose balance is to increase.  *)
+(* @param amount:    Number of tokens to be minted.                          *)
+transition Mint(recipient: ByStr20, amount: Uint128)
+  IsOwner _sender;
+  AuthorizedMint recipient amount;
+  (* Prevent sending to a contract address that does not support transfers of token *)
+  msg_to_recipient = {_tag : "RecipientAcceptMint"; _recipient : recipient; _amount : zero; 
+                      minter : _sender; recipient : recipient; amount : amount};
+  msg_to_sender = {_tag : "MintSuccessCallBack"; _recipient : _sender; _amount : zero; 
+                      minter : _sender; recipient : recipient; amount : amount};
+  msgs = two_msgs msg_to_recipient msg_to_sender;
+  send msgs
+end
+
+(* @dev: Burn existing tokens. Only contract_owner can burn.                      *)
+(* @param burn_account: Address of the token_owner whose balance is to decrease.  *)
+(* @param amount:       Number of tokens to be burned.                            *)
+transition Burn(burn_account: ByStr20, amount: Uint128)
+  IsOwner _sender;
+  AuthorizedBurnIfSufficientBalance burn_account amount;
+  msg_to_sender = {_tag : "BurnSuccessCallBack"; _recipient : _sender; _amount : zero; 
+                    burner : _sender; burn_account : burn_account; amount : amount};
+  msgs = one_msg msg_to_sender;
+  send msgs
+end
 
 (* @dev: Increase the allowance of an approved_spender over the caller tokens. Only token_owner allowed to invoke.   *)
 (* param spender:      Address of the designated approved_spender.                                                   *)

--- a/reference/FungibleToken-Operator.scilla
+++ b/reference/FungibleToken-Operator.scilla
@@ -25,6 +25,7 @@ type Error =
   | CodeNoBalance
   | CodeInsufficientFunds
   | CodeInsufficientAllowanceOrFunds
+  | CodeNotApprovedOperator
 
 let make_error =
   fun (result : Error) =>
@@ -36,6 +37,7 @@ let make_error =
       | CodeNoBalance                    => Int32 -4
       | CodeInsufficientFunds            => Int32 -5
       | CodeInsufficientAllowanceOrFunds => Int32 -6
+      | CodeNotApprovedOperator          => Int32 -7
       end
     in
     { _exception : "Error"; code : result_code }
@@ -62,6 +64,9 @@ let f_eq =
   fun (b : ByStr20) =>
     builtin eq a b
 
+(* Instantiate a type function to test membership in a list *)
+let is_default_operator = @list_mem ByStr20
+
 let get_val =
   fun (some_val: Option Uint128) =>
   match some_val with
@@ -79,7 +84,8 @@ contract FungibleToken
   name : String,
   symbol: String,
   decimals: Uint32,
-  init_supply : Uint128
+  init_supply : Uint128,
+  default_operators : List ByStr20
 )
 
 (* Mutable fields *)
@@ -92,6 +98,12 @@ field balances: Map ByStr20 Uint128
 
 field allowances: Map ByStr20 (Map ByStr20 Uint128) 
   = Emp ByStr20 (Map ByStr20 Uint128)
+
+field operators: Map ByStr20 (Map ByStr20 Unit) 
+  = Emp ByStr20 (Map ByStr20 Unit)
+
+field revoked_default_operators : Map ByStr20 (Map ByStr20 Unit) 
+  = Emp ByStr20 (Map ByStr20 Unit)
 
 (**************************************)
 (*             Procedures             *)
@@ -119,6 +131,22 @@ procedure IsNotSender(address: ByStr20)
     err = CodeIsSender;
     ThrowError err
   | False =>
+  end
+end
+
+procedure IsApprovedOperator(token_owner: ByStr20, operator: ByStr20)
+  is_operator_approved <- exists operators[token_owner][operator];
+  is_default_operator = is_default_operator f_eq operator default_operators;
+  is_revoked_operator <- exists revoked_default_operators[token_owner][operator];
+  is_default_operator_approved = 
+    let is_not_revoked_operator = negb is_revoked_operator in 
+    andb is_not_revoked_operator is_default_operator;
+  is_approved = orb is_operator_approved is_default_operator_approved;
+  match is_approved with
+  | True =>
+  | False =>
+    err = CodeNotApprovedOperator;
+    ThrowError err
   end
 end
 
@@ -191,6 +219,19 @@ end
 (*             Transitions             *)
 (***************************************)
 
+(* Getter transitions *)
+
+(* @dev: Check if an address is an operator or default operator of a token_owner. Throw if not. *)
+(* @param operator:    Address of a potential operator.                                         *)
+(* @param token_owner: Address of a token_owner.                                                *)
+transition IsOperatorFor(token_owner: ByStr20, operator: ByStr20)
+  IsApprovedOperator token_owner operator;
+  msg_to_sender = {_tag : "IsOperatorForCallBack"; _recipient : _sender; _amount : zero;
+                    token_owner: token_owner; operator : operator};
+  msgs = one_msg msg_to_sender;
+  send msgs
+end
+
 (* Optional transitions *)
 
 (* @dev: Mint new tokens. Only contract_owner can mint.                      *)
@@ -221,6 +262,33 @@ transition Burn(burn_account: ByStr20, amount: Uint128)
 end
 
 (* Compulsory interface transitions *)
+
+(* @dev: Make an address an operator of the caller.             *)
+(* @param operator: Address to be authorize as operator or      *)
+(* Re-authorize as default_operator. Cannot be calling address. *)
+transition AuthorizeOperator(operator: ByStr20)
+  IsNotSender operator;
+  (* Re-authorize default_operator if exists *)
+  delete revoked_default_operators[_sender][operator];
+  (* Authorize new operator if not default_operator *)
+  verdad = Unit;
+  operators[_sender][operator] := verdad;
+  e = {_eventname : "AuthorizeOperatorSuccess"; authorizer : _sender; authorized_operator : operator};
+  event e
+end
+
+(* @dev: Revoke an address from being an operator or default_operator of the caller. *)
+(* @param operator: Address to be removed as operator or default_operator.           *)
+transition RevokeOperator(operator: ByStr20)
+  IsApprovedOperator _sender operator;
+  (* Remove operator if exists *)
+  delete operators[_sender][operator];
+  (* Revoke default_operator if exists *)
+  verdad = Unit;
+  revoked_default_operators[_sender][operator] := verdad;
+  e = {_eventname : "RevokeOperatorSuccess"; revoker : _sender; revoked_operator : operator};
+  event e
+end
 
 (* @dev: Increase the allowance of an approved_spender over the caller tokens. Only token_owner allowed to invoke.   *)
 (* param spender:      Address of the designated approved_spender.                                                   *)
@@ -266,6 +334,25 @@ transition Transfer(to: ByStr20, amount: Uint128)
                       sender : _sender; recipient : to; amount : amount};
   msg_to_sender = {_tag : "TransferSuccessCallBack"; _recipient : _sender; _amount : zero; 
                   sender : _sender; recipient : to; amount : amount};
+  msgs = two_msgs msg_to_recipient msg_to_sender;
+  send msgs
+end
+
+(* @dev: Moves amount tokens from token_owner to recipient. _sender must be an operator of token_owner. *)
+(* @dev: Balance of recipient will increase. Balance of token_owner will decrease.                      *)
+(* @param from:        Address of the token_owner whose balance is decreased.                           *)
+(* @param to:          Address of the recipient whose balance is increased.                             *)
+(* @param amount:      Amount of tokens to be sent.                                                     *)
+transition OperatorSend(from: ByStr20, to: ByStr20, amount: Uint128)
+  IsApprovedOperator from _sender;
+  AuthorizedMoveIfSufficientBalance from to amount;
+  e = {_eventname : "OperatorSendSuccess"; initiator : _sender; sender : from; recipient : to; amount : amount};
+  event e;
+  (* Prevent sending to a contract address that does not support transfers of token *)
+  msg_to_recipient = {_tag : "RecipientAcceptOperatorSend"; _recipient : to; _amount : zero; 
+                      initiator : _sender; sender : from; recipient : to; amount : amount};
+  msg_to_sender = {_tag : "OperatorSendSuccessCallBack"; _recipient : _sender; _amount : zero; 
+                  initiator : _sender; sender : from; recipient : to; amount : amount};
   msgs = two_msgs msg_to_recipient msg_to_sender;
   send msgs
 end

--- a/reference/FungibleToken-Operator.scilla
+++ b/reference/FungibleToken-Operator.scilla
@@ -19,25 +19,19 @@ fun (msg2 : Message) =>
 
 (* Error events *)
 type Error =
-  | CodeNotOwner
   | CodeIsSender
-  | CodeNotApprovedSpender
-  | CodeNoBalance
   | CodeInsufficientFunds
-  | CodeInsufficientAllowanceOrFunds
+  | CodeInsufficientAllowance
   | CodeNotApprovedOperator
 
 let make_error =
   fun (result : Error) =>
     let result_code = 
       match result with
-      | CodeNotOwner                     => Int32 -1
-      | CodeIsSender                     => Int32 -2
-      | CodeNotApprovedSpender           => Int32 -3
-      | CodeNoBalance                    => Int32 -4
-      | CodeInsufficientFunds            => Int32 -5
-      | CodeInsufficientAllowanceOrFunds => Int32 -6
-      | CodeNotApprovedOperator          => Int32 -7
+      | CodeIsSender              => Int32 -1
+      | CodeInsufficientFunds     => Int32 -2
+      | CodeInsufficientAllowance => Int32 -3
+      | CodeNotApprovedOperator   => Int32 -5
       end
     in
     { _exception : "Error"; code : result_code }
@@ -47,16 +41,6 @@ let zero = Uint128 0
 (* Dummy user-defined ADT *)
 type Unit =
 | Unit
-
-let min_int =
-  fun (a : Uint128) => fun (b : Uint128) =>
-  let min = builtin lt a b in
-  match min with
-  | True =>
-    a
-  | False =>
-    b
-  end
     
 (* A util function to test equality *)
 let f_eq =
@@ -114,16 +98,6 @@ procedure ThrowError(err : Error)
   throw e
 end
 
-procedure IsOwner(address: ByStr20)
-  is_owner = builtin eq contract_owner address;
-  match is_owner with
-  | True =>
-  | False =>
-    err = CodeNotOwner;
-    ThrowError err
-  end
-end
-
 procedure IsNotSender(address: ByStr20)
   is_sender = builtin eq _sender address;
   match is_sender with
@@ -146,43 +120,6 @@ procedure IsApprovedOperator(token_owner: ByStr20, operator: ByStr20)
   | True =>
   | False =>
     err = CodeNotApprovedOperator;
-    ThrowError err
-  end
-end
-
-procedure AuthorizedMint(recipient: ByStr20, amount: Uint128) 
-  some_bal <- balances[recipient];
-  bal = get_val some_bal;
-  new_balance = builtin add amount bal;
-  balances[recipient] := new_balance;
-  current_total_supply <- total_supply;
-  new_total_supply = builtin add current_total_supply amount;
-  total_supply := new_total_supply;
-  e = {_eventname: "Minted"; minter: _sender; recipient: recipient; amount: amount};
-  event e
-end
-
-procedure AuthorizedBurnIfSufficientBalance(from: ByStr20, amount: Uint128)
-  get_bal <- balances[from];
-  match get_bal with
-  | Some bal =>
-    can_burn = uint128_le amount bal;
-    match can_burn with
-    | True =>
-      (* Subtract amount from from *)
-      new_balance = builtin sub bal amount;
-      balances[from] := new_balance;
-      current_total_supply <- total_supply;
-      new_total_supply = builtin sub current_total_supply amount;
-      total_supply := new_total_supply;
-      e = {_eventname: "Burnt"; burner: _sender; burn_account: from; amount: amount};
-      event e  
-    | False =>
-      err = CodeInsufficientFunds;
-      ThrowError err
-    end
-  | None => 
-    err = CodeNoBalance;
     ThrowError err
   end
 end
@@ -210,7 +147,7 @@ procedure AuthorizedMoveIfSufficientBalance(from: ByStr20, to: ByStr20, amount: 
       ThrowError err
     end
   | None =>
-    err = CodeNoBalance;
+    err = CodeInsufficientFunds;
     ThrowError err
   end
 end
@@ -231,37 +168,6 @@ transition IsOperatorFor(token_owner: ByStr20, operator: ByStr20)
   msgs = one_msg msg_to_sender;
   send msgs
 end
-
-(* Optional transitions *)
-
-(* @dev: Mint new tokens. Only contract_owner can mint.                      *)
-(* @param recipient: Address of the recipient whose balance is to increase.  *)
-(* @param amount:    Number of tokens to be minted.                          *)
-transition Mint(recipient: ByStr20, amount: Uint128)
-  IsOwner _sender;
-  AuthorizedMint recipient amount;
-  (* Prevent sending to a contract address that does not support transfers of token *)
-  msg_to_recipient = {_tag : "RecipientAcceptMint"; _recipient : recipient; _amount : zero; 
-                      minter : _sender; recipient : recipient; amount : amount};
-  msg_to_sender = {_tag : "MintSuccessCallBack"; _recipient : _sender; _amount : zero; 
-                      minter : _sender; recipient : recipient; amount : amount};
-  msgs = two_msgs msg_to_recipient msg_to_sender;
-  send msgs
-end
-
-(* @dev: Burn existing tokens. Only contract_owner can burn.                      *)
-(* @param burn_account: Address of the token_owner whose balance is to decrease.  *)
-(* @param amount:       Number of tokens to be burned.                            *)
-transition Burn(burn_account: ByStr20, amount: Uint128)
-  IsOwner _sender;
-  AuthorizedBurnIfSufficientBalance burn_account amount;
-  msg_to_sender = {_tag : "BurnSuccessCallBack"; _recipient : _sender; _amount : zero; 
-                    burner : _sender; burn_account : burn_account; amount : amount};
-  msgs = one_msg msg_to_sender;
-  send msgs
-end
-
-(* Compulsory interface transitions *)
 
 (* @dev: Make an address an operator of the caller.             *)
 (* @param operator: Address to be authorize as operator or      *)
@@ -338,6 +244,40 @@ transition Transfer(to: ByStr20, amount: Uint128)
   send msgs
 end
 
+(* @dev: Move a given amount of tokens from one address to another using the allowance mechanism. The caller must be an approved_spender. *)
+(* @dev: Balance of recipient will increase. Balance of token_owner will decrease.                                                        *)
+(* @param from:    Address of the token_owner whose balance is decreased.                                                                 *)
+(* @param to:      Address of the recipient whose balance is increased.                                                                   *)
+(* @param amount:  Amount of tokens to be transferred.                                                                                    *)
+transition TransferFrom(from: ByStr20, to: ByStr20, amount: Uint128)
+  get_spender_allowed <- allowances[from][_sender];
+  match get_spender_allowed with
+  | Some allowed =>
+    can_do = uint128_le amount allowed;
+    match can_do with
+    | True =>
+      AuthorizedMoveIfSufficientBalance from to amount;
+      e = {_eventname : "TransferFromSuccess"; initiator : _sender; sender : from; recipient : to; amount : amount};
+      event e;
+      new_allowed = builtin sub allowed amount;
+      allowances[from][_sender] := new_allowed;
+      (* Prevent sending to a contract address that does not support transfers of token *)
+      msg_to_recipient = {_tag : "RecipientAcceptTransferFrom"; _recipient : to; _amount : zero; 
+                          initiator : _sender; sender : from; recipient : to; amount : amount};
+      msg_to_sender = {_tag : "TransferFromSuccessCallBack"; _recipient : _sender; _amount : zero; 
+                      initiator : _sender; sender : from; recipient : to; amount : amount};
+      msgs = two_msgs msg_to_recipient msg_to_sender;
+      send msgs
+    | False =>
+      err = CodeInsufficientAllowance;
+      ThrowError err
+    end
+  | None =>
+    err = CodeInsufficientAllowance;
+    ThrowError err
+  end
+end
+
 (* @dev: Moves amount tokens from token_owner to recipient. _sender must be an operator of token_owner. *)
 (* @dev: Balance of recipient will increase. Balance of token_owner will decrease.                      *)
 (* @param from:        Address of the token_owner whose balance is decreased.                           *)
@@ -355,46 +295,4 @@ transition OperatorSend(from: ByStr20, to: ByStr20, amount: Uint128)
                   initiator : _sender; sender : from; recipient : to; amount : amount};
   msgs = two_msgs msg_to_recipient msg_to_sender;
   send msgs
-end
-
-(* @dev: Move a given amount of tokens from one address to another using the allowance mechanism. The caller must be an approved_spender. *)
-(* @dev: Balance of recipient will increase. Balance of token_owner will decrease.                                                        *)
-(* @param from:    Address of the token_owner whose balance is decreased.                                                                 *)
-(* @param to:      Address of the recipient whose balance is increased.                                                                   *)
-(* @param amount:  Amount of tokens to be transferred.                                                                                    *)
-transition TransferFrom(from: ByStr20, to: ByStr20, amount: Uint128)
-  get_bal <- balances[from];
-  match get_bal with
-  | Some bal =>
-    get_spender_allowed <- allowances[from][_sender];
-    match get_spender_allowed with
-    | Some allowed =>
-      min = min_int bal allowed;
-      can_do = uint128_le amount min;
-      match can_do with
-      | True =>
-        AuthorizedMoveIfSufficientBalance from to amount;
-        e = {_eventname : "TransferFromSuccess"; initiator : _sender; sender : from; recipient : to; amount : amount};
-        event e;
-        new_allowed = builtin sub allowed amount;
-        allowances[from][_sender] := new_allowed;
-        (* Prevent sending to a contract address that does not support transfers of token *)
-        msg_to_recipient = {_tag : "RecipientAcceptTransferFrom"; _recipient : to; _amount : zero; 
-                            initiator : _sender; sender : from; recipient : to; amount : amount};
-        msg_to_sender = {_tag : "TransferFromSuccessCallBack"; _recipient : _sender; _amount : zero; 
-                        initiator : _sender; sender : from; recipient : to; amount : amount};
-        msgs = two_msgs msg_to_recipient msg_to_sender;
-        send msgs
-      | False =>
-        err = CodeInsufficientAllowanceOrFunds;
-        ThrowError err
-      end
-    | None =>
-      err = CodeNotApprovedSpender;
-      ThrowError err
-    end
-  | None => 
-    err = CodeNoBalance;
-    ThrowError err
-  end
 end

--- a/reference/FungibleToken.scilla
+++ b/reference/FungibleToken.scilla
@@ -21,11 +21,11 @@ fun (msg2 : Message) =>
 type Error =
   | CodeNotOwner
   | CodeIsSender
-  | CodeNotApprovedOperator
   | CodeNotApprovedSpender
   | CodeNoBalance
   | CodeInsufficientFunds
   | CodeInsufficientAllowanceOrFunds
+  | CodeNotApprovedOperator
 
 let make_error =
   fun (result : Error) =>
@@ -33,11 +33,11 @@ let make_error =
       match result with
       | CodeNotOwner                     => Int32 -1
       | CodeIsSender                     => Int32 -2
-      | CodeNotApprovedOperator          => Int32 -3
-      | CodeNotApprovedSpender           => Int32 -4
-      | CodeNoBalance                    => Int32 -5
-      | CodeInsufficientFunds            => Int32 -6
-      | CodeInsufficientAllowanceOrFunds => Int32 -7
+      | CodeNotApprovedSpender           => Int32 -3
+      | CodeNoBalance                    => Int32 -4
+      | CodeInsufficientFunds            => Int32 -5
+      | CodeInsufficientAllowanceOrFunds => Int32 -6
+      | CodeNotApprovedOperator          => Int32 -7
       end
     in
     { _exception : "Error"; code : result_code }
@@ -84,8 +84,8 @@ contract FungibleToken
   name : String,
   symbol: String,
   decimals: Uint32,
-  default_operators : List ByStr20,
-  init_supply : Uint128
+  init_supply : Uint128,
+  default_operators : List ByStr20
 )
 
 (* Mutable fields *)
@@ -96,14 +96,14 @@ field balances: Map ByStr20 Uint128
   = let emp_map = Emp ByStr20 Uint128 in
     builtin put emp_map contract_owner init_supply
 
+field allowances: Map ByStr20 (Map ByStr20 Uint128) 
+  = Emp ByStr20 (Map ByStr20 Uint128)
+
 field operators: Map ByStr20 (Map ByStr20 Unit) 
   = Emp ByStr20 (Map ByStr20 Unit)
 
 field revoked_default_operators : Map ByStr20 (Map ByStr20 Unit) 
   = Emp ByStr20 (Map ByStr20 Unit)
-
-field allowances: Map ByStr20 (Map ByStr20 Uint128) 
-  = Emp ByStr20 (Map ByStr20 Uint128)
 
 (**************************************)
 (*             Procedures             *)

--- a/zrcs/zrc-2.md
+++ b/zrcs/zrc-2.md
@@ -341,7 +341,8 @@ transition TransferFrom(from: ByStr20, to: ByStr20, amount: Uint128)
 
 ## V. Existing Implementation(s)
 
-- [Fungible Token Reference contract](../reference/FungibleToken.scilla)
+- [ZRC2 Reference contract](../reference/FungibleToken.scilla)
+- [ZRC2-Operator Reference contract](../reference/FungibleToken-Operator.scilla)
 
 To test the reference contract, simply go to the [`example`](../example) folder and run one of the JS scripts. For example, to deploy the contract, run:
 

--- a/zrcs/zrc-2.md
+++ b/zrcs/zrc-2.md
@@ -114,8 +114,8 @@ transition Mint(recipient: ByStr20, amount: Uint128)
 
 |        | Name                  | Description                                           | Callback Parameters                                                                                                                                                                                                |
 | ------ | --------------------- | ----------------------------------------------------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------ |
-| `_tag` | `recipientAcceptMint` | Dummy callback to prevent invalid recipient contract. | `minter` : `ByStr20`, `recipient`: `ByStr20`, `amount`: `Uint128`, where `minter` is the address of the minter, `recipient` is the address of the recipient, and `amount` is the amount of fungible tokens minted. |
-| `_tag` | `mintSuccessCallBack` | Provide the sender the status of the mint.            | `minter` : `ByStr20`, `recipient`: `ByStr20`, `amount`: `Uint128`, where `minter` is the address of the minter, `recipient` is the address of the recipient, and `amount` is the amount of fungible tokens minted. |
+| `_tag` | `RecipientAcceptMint` | Dummy callback to prevent invalid recipient contract. | `minter` : `ByStr20`, `recipient`: `ByStr20`, `amount`: `Uint128`, where `minter` is the address of the minter, `recipient` is the address of the recipient, and `amount` is the amount of fungible tokens minted. |
+| `_tag` | `MintSuccessCallBack` | Provide the sender the status of the mint.            | `minter` : `ByStr20`, `recipient`: `ByStr20`, `amount`: `Uint128`, where `minter` is the address of the minter, `recipient` is the address of the recipient, and `amount` is the amount of fungible tokens minted. |
 
 **Events:**
 

--- a/zrcs/zrc-2.md
+++ b/zrcs/zrc-2.md
@@ -1,5 +1,5 @@
-| ZRC | Title                        | Status   | Type     | Author                                                                                                                       | Created (yyyy-mm-dd) | Updated (yyyy-mm-dd) |
-| --- | ---------------------------- | -------- | -------- | ---------------------------------------------------------------------------------------------------------------------------- | -------------------- | -------------------- |
+| ZRC | Title                        | Status   | Type     | Author                                                                               | Created (yyyy-mm-dd) | Updated (yyyy-mm-dd) |
+| --- | ---------------------------- | -------- | -------- | ------------------------------------------------------------------------------------ | -------------------- | -------------------- |
 | 2   | Standard for Fungible Tokens | Approved | Standard | Vaivaswatha Nagaraj <vaivaswatha@zilliqa.com> <br> Chua Han Wen <hanwen@zilliqa.com> | 2019-11-18           | 2020-04-25           |
 
 ## I. What are Fungible Tokens?
@@ -25,52 +25,52 @@ The fungible token contract specification describes:
 
 ### A. Roles
 
-| Name               | Description                                                                                                                     |
-| ------------------ | ------------------------------------------------------------------------------------------------------------------------------- |
-| `contract_owner`   | The owner of the contract initialized by the creator of the contract.                                                           |
-| `token_owner`      | A user (identified by an address) that owns tokens.                                                                             |
-| `approved_spender` | A user (identified by an address) that can transfer tokens on behalf of the token_owner.                                        |
-| `operator`         | A user (identified by an address) that is approved to operate all tokens owned by another user (identified by another address). |
-| `default_operator` | A special user (identified by an address) that is approved to operate all tokens owned by all users (identified by addresses).  |
+| Name               | Description                                                                                                                                            |
+| ------------------ | ------------------------------------------------------------------------------------------------------------------------------------------------------ |
+| `contract_owner`   | The owner of the contract initialized by the creator of the contract.                                                                                  |
+| `token_owner`      | A user (identified by an address) that owns tokens.                                                                                                    |
+| `approved_spender` | A user (identified by an address) that can transfer tokens on behalf of the token_owner.                                                               |
+| `operator`         | A user (identified by an address) that is approved to operate all tokens owned by another user (identified by another address). This role is optional. |
+| `default_operator` | A special user (identified by an address) that is approved to operate all tokens owned by all users (identified by addresses). This role is optional.  |
 
 ### B. Error Codes
 
 The fungible token contract must define the following constants for use as error codes for the `Error` exception.
 
-| Name                               | Type    | Code | Description                                                                    |
-| ---------------------------------- | ------- | ---- | ------------------------------------------------------------------------------ |
-| `CodeNotOwner`                     | `Int32` | `-1` | Emit when the sender is not contract_owner.                                    |
-| `CodeIsSender`                     | `Int32` | `-2` | Emit when an address is same as is the sender.                                 |
-| `CodeNotApprovedOperator`          | `Int32` | `-3` | Emit when caller is not an approved operator or default_operator.              |
-| `CodeNotApprovedSpender`           | `Int32` | `-4` | Emit when caller is not an approved_spender.                                   |
-| `CodeNoBalance`                    | `Int32` | `-5` | Emit when there is no balance to authorise transaction.                        |
-| `CodeInsufficientFunds`            | `Int32` | `-6` | Emit when there is insufficient balance to authorise transaction.              |
-| `CodeInsufficientAllowanceOrFunds` | `Int32` | `-7` | Emit when there is insufficient balance or allowance to authorise transaction. |
+| Name                               | Type    | Code | Description                                                                                    |
+| ---------------------------------- | ------- | ---- | ---------------------------------------------------------------------------------------------- |
+| `CodeNotOwner`                     | `Int32` | `-1` | Emit when the sender is not contract_owner.                                                    |
+| `CodeIsSender`                     | `Int32` | `-2` | Emit when an address is same as is the sender.                                                 |
+| `CodeNotApprovedSpender`           | `Int32` | `-3` | Emit when caller is not an approved_spender.                                                   |
+| `CodeNoBalance`                    | `Int32` | `-4` | Emit when there is no balance to authorise transaction.                                        |
+| `CodeInsufficientFunds`            | `Int32` | `-5` | Emit when there is insufficient balance to authorise transaction.                              |
+| `CodeInsufficientAllowanceOrFunds` | `Int32` | `-6` | Emit when there is insufficient balance or allowance to authorise transaction.                 |
+| `CodeNotApprovedOperator`          | `Int32` | `-7` | Emit when caller is not an approved operator or default_operator. This error code is optional. |
 
 ### C. Immutable Variables
 
-| Name                | Type           | Description                                                               |
-| ------------------- | -------------- | ------------------------------------------------------------------------- |
-| `contract_owner`    | `ByStr20`      | The owner of the contract initialized by the creator of the contract.     |
-| `name`              | `String`       | The name of the fungible token.                                           |
-| `symbol`            | `String`       | The symbol of the fungible token.                                         |
-| `decimals`          | `Uint32`       | The number of decimal places a token can be divided by.                   |
-| `default_operators` | `List ByStr20` | The list of default operators initialized by the creator of the contract. |
-| `init_supply`       | `Uint128`      | The initial supply of fungible tokens when contract is created.           |
+| Name                | Type           | Description                                                                                                    |
+| ------------------- | -------------- | -------------------------------------------------------------------------------------------------------------- |
+| `contract_owner`    | `ByStr20`      | The owner of the contract initialized by the creator of the contract.                                          |
+| `name`              | `String`       | The name of the fungible token.                                                                                |
+| `symbol`            | `String`       | The symbol of the fungible token.                                                                              |
+| `decimals`          | `Uint32`       | The number of decimal places a token can be divided by.                                                        |
+| `init_supply`       | `Uint128`      | The initial supply of fungible tokens when contract is created.                                                |
+| `default_operators` | `List ByStr20` | The list of default operators initialized by the creator of the contract. This immutable variable is optional. |
 
 ### D. Mutable Fields
 
-| Name                        | Type                                | Description                                                                                                                                                                                                                  |
-| --------------------------- | ----------------------------------- | ---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
-| `total_supply`              | `Uint128`                           | Total amount of tokens available.                                                                                                                                                                                            |
-| `balances`              | `Map ByStr20 Uint128`               | Mapping between token owner to number of owned tokens.                                                                                                                                                                       |
-| `operators`             | `Map ByStr20 (Map ByStr20 Unit)`    | Mapping from token owner to designated operators. A token owner can approve an address as an operator (as per the definition of operator given above).                                                                       |
-| `revoked_default_operators` | `Map ByStr20 (Map ByStr20 Unit)`    | Mapping from token owner to revoked default operators. Default operators are intialised by the contract owner. A token owner can revoked a default operator (as per the definition of default operator given above) at will. |
-| `allowances`            | `Map ByStr20 (Map ByStr20 Uint128)` | Mapping from token owner to approved spender address. Token owner can give an address an allowance of tokens to transfer tokens to other addresses.                                                                          |
+| Name                        | Type                                | Description                                                                                                                                                                                                                                            |
+| --------------------------- | ----------------------------------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------ |
+| `total_supply`              | `Uint128`                           | Total amount of tokens available.                                                                                                                                                                                                                      |
+| `balances`                  | `Map ByStr20 Uint128`               | Mapping between token owner to number of owned tokens.                                                                                                                                                                                                 |
+| `allowances`                | `Map ByStr20 (Map ByStr20 Uint128)` | Mapping from token owner to approved spender address. Token owner can give an address an allowance of tokens to transfer tokens to other addresses.                                                                                                    |
+| `operators`                 | `Map ByStr20 (Map ByStr20 Unit)`    | Mapping from token owner to designated operators. A token owner can approve an address as an operator (as per the definition of operator given above). This mapping is optional.                                                                       |
+| `revoked_default_operators` | `Map ByStr20 (Map ByStr20 Unit)`    | Mapping from token owner to revoked default operators. Default operators are intialised by the contract owner. A token owner can revoked a default operator (as per the definition of default operator given above) at will. This mapping is optional. |
 
 ### E. Getter Transitions
 
-#### 1. IsOperatorFor()
+#### 1. IsOperatorFor() (Optional)
 
 ```ocaml
 (* @dev: Check if an address is an operator or default operator of a token_owner. Throw if not. *)
@@ -153,7 +153,7 @@ transition Burn(burn_account: ByStr20, amount: Uint128)
 | `_eventname` | `Burnt` | Burning is successful.     | `burner` : `ByStr20`, `burn_account`: `ByStr20`, `amount`: `Uint128`, where `burner` is the address of the burner, `burn_account` is the address whose balance will be decreased, and `amount` is the amount of fungible tokens burned.                         |
 | `_eventname` | `Error` | Burning is not successful. | - emit `CodeNotOwner` if the transition is not called by the contract_owner. <br> - emit `CodeNoBalance` if balance of token_owner does not exists. <br> - emit `CodeInsufficientFunds` if the amount to be burned is more than the balance of the token_owner. |
 
-#### 3. AuthorizeOperator()
+#### 3. AuthorizeOperator() (Optional)
 
 ```ocaml
 (* @dev: Make an address an operator of the caller.             *)
@@ -175,7 +175,7 @@ transition AuthorizeOperator(operator: ByStr20)
 | `_eventname` | `AuthorizeOperatorSuccess` | Authorizing is successful.     | `authorizer`: `ByStr20` which is the caller's address, and `authorized_operator`: `ByStr20` which is the address to be authorized as an operator of the token_owner. |
 | `_eventname` | `Error`                    | Authorizing is not successful. | - emit `CodeIsSender` if the user is trying to authorize himself as an operator.                                                                                     |
 
-#### 4. RevokeOperator()
+#### 4. RevokeOperator() (Optional)
 
 ```ocaml
 (* @dev: Revoke an address from being an operator or default_operator of the caller. *)
@@ -268,12 +268,12 @@ transition Transfer(to: ByStr20, amount: Uint128)
 
 **Events:**
 
-|              | Name       | Description                | Event Parameters                                                                                                                                                                                      |
-| ------------ | ---------- | -------------------------- | ----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+|              | Name              | Description                | Event Parameters                                                                                                                                                                                      |
+| ------------ | ----------------- | -------------------------- | ----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
 | `_eventname` | `TransferSuccess` | Sending is successful.     | `sender`: `ByStr20` which is the sender's address, `recipient`: `ByStr20` which is the recipient's address, and `amount`: `Uint128` which is the amount of fungible tokens transferred.               |
-| `_eventname` | `Error`    | Sending is not successful. | - emit `CodeNoBalance` if the balance of token_owner is not found. <br> - emit `CodeInsufficientFunds` if the balance of the token_owner lesser than the specified amount that was to be transferred. |
+| `_eventname` | `Error`           | Sending is not successful. | - emit `CodeNoBalance` if the balance of token_owner is not found. <br> - emit `CodeInsufficientFunds` if the balance of the token_owner lesser than the specified amount that was to be transferred. |
 
-#### 8. OperatorSend()
+#### 8. OperatorSend() (Optional)
 
 ```ocaml
 (* @dev: Moves amount tokens from token_owner to recipient. _sender must be an operator of token_owner. *)

--- a/zrcs/zrc-2.md
+++ b/zrcs/zrc-2.md
@@ -37,15 +37,13 @@ The fungible token contract specification describes:
 
 The fungible token contract must define the following constants for use as error codes for the `Error` exception.
 
-| Name                               | Type    | Code | Description                                                                                    |
-| ---------------------------------- | ------- | ---- | ---------------------------------------------------------------------------------------------- |
-| `CodeNotOwner`                     | `Int32` | `-1` | Emit when the sender is not contract_owner.                                                    |
-| `CodeIsSender`                     | `Int32` | `-2` | Emit when an address is same as is the sender.                                                 |
-| `CodeNotApprovedSpender`           | `Int32` | `-3` | Emit when caller is not an approved_spender.                                                   |
-| `CodeNoBalance`                    | `Int32` | `-4` | Emit when there is no balance to authorise transaction.                                        |
-| `CodeInsufficientFunds`            | `Int32` | `-5` | Emit when there is insufficient balance to authorise transaction.                              |
-| `CodeInsufficientAllowanceOrFunds` | `Int32` | `-6` | Emit when there is insufficient balance or allowance to authorise transaction.                 |
-| `CodeNotApprovedOperator`          | `Int32` | `-7` | Emit when caller is not an approved operator or default_operator. This error code is optional. |
+| Name                        | Type    | Code | Description                                                                                    |
+| --------------------------- | ------- | ---- | ---------------------------------------------------------------------------------------------- |
+| `CodeIsSender`              | `Int32` | `-1` | Emit when an address is same as is the sender.                                                 |
+| `CodeInsufficientFunds`     | `Int32` | `-2` | Emit when there is insufficient balance to authorise transaction.                              |
+| `CodeInsufficientAllowance` | `Int32` | `-3` | Emit when there is insufficient allowance to authorise transaction.                            |
+| `CodeNotOwner`              | `Int32` | `-4` | Emit when the sender is not contract_owner. This error code is optional.                       |
+| `CodeNotApprovedOperator`   | `Int32` | `-5` | Emit when caller is not an approved operator or default_operator. This error code is optional. |
 
 ### C. Immutable Variables
 
@@ -117,7 +115,7 @@ transition Mint(recipient: ByStr20, amount: Uint128)
 | `_tag` | `RecipientAcceptMint` | Dummy callback to prevent invalid recipient contract. | `minter` : `ByStr20`, `recipient`: `ByStr20`, `amount`: `Uint128`, where `minter` is the address of the minter, `recipient` is the address of the recipient, and `amount` is the amount of fungible tokens minted. |
 | `_tag` | `MintSuccessCallBack` | Provide the sender the status of the mint.            | `minter` : `ByStr20`, `recipient`: `ByStr20`, `amount`: `Uint128`, where `minter` is the address of the minter, `recipient` is the address of the recipient, and `amount` is the amount of fungible tokens minted. |
 
-**Events:**
+**Events/Errors:**
 
 |              | Name     | Description                | Event Parameters                                                                                                                                                                                                                  |
 | ------------ | -------- | -------------------------- | --------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
@@ -146,7 +144,7 @@ transition Burn(burn_account: ByStr20, amount: Uint128)
 | ------ | --------------------- | ------------------------------------------ | --------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
 | `_tag` | `BurnSuccessCallBack` | Provide the sender the status of the burn. | `burner` : `ByStr20`, `burn_account`: `ByStr20`, `amount`: `Uint128`, where `burner` is the address of the burner, `burn_account` is the address whose balance will be decreased, and `amount` is the amount of fungible tokens burned. |
 
-**Events:**
+**Events/Errors:**
 
 |              | Name    | Description                | Event Parameters                                                                                                                                                                                                                                                |
 | ------------ | ------- | -------------------------- | --------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
@@ -168,7 +166,7 @@ transition AuthorizeOperator(operator: ByStr20)
 | ------ | ---------- | --------- | --------------------------------------------------------------------------------------------------- |
 | @param | `operator` | `ByStr20` | Address to be authorize as operator or re-authorize as default_operator. Cannot be calling address. |
 
-**Events:**
+**Events/Errors:**
 
 |              | Name                       | Description                    | Event Parameters                                                                                                                                                     |
 | ------------ | -------------------------- | ------------------------------ | -------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
@@ -189,7 +187,7 @@ transition RevokeOperator(operator: ByStr20)
 | ------ | ---------- | --------- | -------------------------------- |
 | @param | `operator` | `ByStr20` | Address to be unset as operator. |
 
-**Events:**
+**Events/Errors:**
 
 |              | Name                    | Description                 | Event Parameters                                                                                                                                            |
 | ------------ | ----------------------- | --------------------------- | ----------------------------------------------------------------------------------------------------------------------------------------------------------- |
@@ -212,7 +210,7 @@ transition IncreaseAllowance(spender: ByStr20, amount: Uint128)
 | @param | `spender` | `ByStr20` | Address of an approved_spender.                                                 |
 | @param | `amount`  | `Uint128` | Number of tokens to be increased as spending allowance of the approved_spender. |
 
-**Events:**
+**Events/Errors:**
 
 |              | Name                 | Description                                                   | Event Parameters                                                                                                                                                                                                                                  |
 | ------------ | -------------------- | ------------------------------------------------------------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
@@ -235,7 +233,7 @@ transition DecreaseAllowance(spender: ByStr20, amount: Uint128)
 | @param | `spender` | `ByStr20` | Address of an approved_spender.                                                 |
 | @param | `amount`  | `Uint128` | Number of tokens to be decreased as spending allowance of the approved_spender. |
 
-**Events:**
+**Events/Errors:**
 
 |              | Name                 | Description                                                   | Event Parameters                                                                                                                                                                                                                                  |
 | ------------ | -------------------- | ------------------------------------------------------------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
@@ -266,47 +264,14 @@ transition Transfer(to: ByStr20, amount: Uint128)
 | `_tag` | `RecipientAcceptTransfer` | Dummy callback to prevent invalid recipient contract. | `sender` : `ByStr20`, `recipient`: `ByStr20`, `amount`: `Uint128`, where `sender` is the address of the sender, `recipient` is the address of the recipient, and `amount` is the amount of fungible tokens to be transferred. |
 | `_tag` | `TransferSuccessCallBack` | Provide the sender the status of the transfer.        | `sender` : `ByStr20`, `recipient`: `ByStr20`, `amount`: `Uint128`, where `sender` is the address of the sender, `recipient` is the address of the recipient, and `amount` is the amount of fungible tokens to be transferred. |
 
-**Events:**
+**Events/Errors:**
 
-|              | Name              | Description                | Event Parameters                                                                                                                                                                                      |
-| ------------ | ----------------- | -------------------------- | ----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
-| `_eventname` | `TransferSuccess` | Sending is successful.     | `sender`: `ByStr20` which is the sender's address, `recipient`: `ByStr20` which is the recipient's address, and `amount`: `Uint128` which is the amount of fungible tokens transferred.               |
-| `_eventname` | `Error`           | Sending is not successful. | - emit `CodeNoBalance` if the balance of token_owner is not found. <br> - emit `CodeInsufficientFunds` if the balance of the token_owner lesser than the specified amount that was to be transferred. |
+|              | Name              | Description                | Event Parameters                                                                                                                                                                        |
+| ------------ | ----------------- | -------------------------- | --------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| `_eventname` | `TransferSuccess` | Sending is successful.     | `sender`: `ByStr20` which is the sender's address, `recipient`: `ByStr20` which is the recipient's address, and `amount`: `Uint128` which is the amount of fungible tokens transferred. |
+| `_eventname` | `Error`           | Sending is not successful. | - emit `CodeInsufficientFunds` if the balance of the token_owner lesser than the specified amount that is to be transferred.                                                            |
 
-#### 8. OperatorSend() (Optional)
-
-```ocaml
-(* @dev: Moves amount tokens from token_owner to recipient. _sender must be an operator of token_owner. *)
-(* @dev: Balance of recipient will increase. Balance of token_owner will decrease.                      *)
-(* @param from:        Address of the token_owner whose balance is decreased.                           *)
-(* @param to:          Address of the recipient whose balance is increased.                             *)
-(* @param amount:      Amount of tokens to be sent.                                                     *)
-transition OperatorSend(from: ByStr20, to: ByStr20, amount: Uint128)
-```
-
-**Arguments:**
-
-|        | Name     | Type      | Description                                              |
-| ------ | -------- | --------- | -------------------------------------------------------- |
-| @param | `from`   | `ByStr20` | Address of the token_owner whose balance is to decrease. |
-| @param | `to`     | `ByStr20` | Address of the recipient whose balance is to increase.   |
-| @param | `amount` | `Uint128` | Amount of tokens to be sent.                             |
-
-**Messages sent:**
-
-|        | Name                          | Description                                           | Callback Parameters                                                                                                                                                                                                                                                                                  |
-| ------ | ----------------------------- | ----------------------------------------------------- | ---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
-| `_tag` | `RecipientAcceptOperatorSend` | Dummy callback to prevent invalid recipient contract. | `initiator`: `ByStr20`, `sender` : `ByStr20`, `recipient`: `ByStr20`, `amount`: `Uint128`, where `initiator` is the address of an operator,`sender` is the address of the token_owner, `recipient` is the address of the recipient, and `amount` is the amount of fungible tokens to be transferred. |
-| `_tag` | `OperatorSendSuccessCallBack` | Provide the sender the status of the transfer.        | `initiator`: `ByStr20`, `sender` : `ByStr20`, `recipient`: `ByStr20`, `amount`: `Uint128`, where `initiator` is the address of an operator,`sender` is the address of the token_owner, `recipient` is the address of the recipient, and `amount` is the amount of fungible tokens to be transferred. |
-
-**Events:**
-
-|              | Name                  | Description                | Event Parameters                                                                                                                                                                                                                                                                                       |
-| ------------ | --------------------- | -------------------------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------ |
-| `_eventname` | `OperatorSendSuccess` | Sending is successful.     | `initiator`: `ByStr20` which is the operator's address, `sender`: `ByStr20` which is the token_owner's address, `recipient`: `ByStr20` which is the recipient's address, and `amount`: `Uint128` which is the amount of fungible tokens to be transferred.                                             |
-| `_eventname` | `Error`               | Sending is not successful. | - emit `CodeNotApprovedOperator` if sender is not an approved operator for the token_owner <br> emit `CodeNoBalance` if the balance of token_owner is not found. <br> - emit `CodeInsufficientFunds` if the balance of the token_owner is lesser than the specified amount that was to be transferred. |
-
-#### 9. TransferFrom()
+#### 8. TransferFrom()
 
 ```ocaml
 (* @dev: Move a given amount of tokens from one address to another using the allowance mechanism. The caller must be an approved_spender. *)
@@ -334,14 +299,48 @@ transition TransferFrom(from: ByStr20, to: ByStr20, amount: Uint128)
 
 **Events:**
 
-|              | Name                  | Description                | Event Parameters                                                                                                                                                                                                                                                                                                                         |
-| ------------ | --------------------- | -------------------------- | ---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
-| `_eventname` | `TransferFromSuccess` | Sending is successful.     | `initiator`: `ByStr20`, `sender` : `ByStr20`, `recipient`: `ByStr20`, `amount`: `Uint128`, where `initiator` is the address of an approved_spender,`sender` is the address of the token_owner, `recipient` is the address of the recipient, and `amount` is the amount of fungible tokens to be transferred.                             |
-| `_eventname` | `Error`               | Sending is not successful. | - emit `CodeNotApprovedSpender` if sender is not an approved_spender for the token_owner <br> emit `CodeNoBalance` if the balance of token_owner is not found. <br> - emit `CodeInsufficientAllowanceOrFunds` if the allowance of operator or balance of the token_owner is lesser than the specified amount that was to be transferred. |
+|              | Name                  | Description                | Event Parameters                                                                                                                                                                                                                                                                                             |
+| ------------ | --------------------- | -------------------------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------ |
+| `_eventname` | `TransferFromSuccess` | Sending is successful.     | `initiator`: `ByStr20`, `sender` : `ByStr20`, `recipient`: `ByStr20`, `amount`: `Uint128`, where `initiator` is the address of an approved_spender,`sender` is the address of the token_owner, `recipient` is the address of the recipient, and `amount` is the amount of fungible tokens to be transferred. |
+| `_eventname` | `Error`               | Sending is not successful. | - emit `CodeInsufficientAllowance` if the allowance of approved_spender is lesser than the specified amount that is to be transferred. <br> - emit `CodeInsufficientFunds` if the balance of the token_owner lesser than the specified amount that is to be transferred.                                     |
+
+#### 9. OperatorSend() (Optional)
+
+```ocaml
+(* @dev: Moves amount tokens from token_owner to recipient. _sender must be an operator of token_owner. *)
+(* @dev: Balance of recipient will increase. Balance of token_owner will decrease.                      *)
+(* @param from:        Address of the token_owner whose balance is decreased.                           *)
+(* @param to:          Address of the recipient whose balance is increased.                             *)
+(* @param amount:      Amount of tokens to be sent.                                                     *)
+transition OperatorSend(from: ByStr20, to: ByStr20, amount: Uint128)
+```
+
+**Arguments:**
+
+|        | Name     | Type      | Description                                              |
+| ------ | -------- | --------- | -------------------------------------------------------- |
+| @param | `from`   | `ByStr20` | Address of the token_owner whose balance is to decrease. |
+| @param | `to`     | `ByStr20` | Address of the recipient whose balance is to increase.   |
+| @param | `amount` | `Uint128` | Amount of tokens to be sent.                             |
+
+**Messages sent:**
+
+|        | Name                          | Description                                           | Callback Parameters                                                                                                                                                                                                                                                                                  |
+| ------ | ----------------------------- | ----------------------------------------------------- | ---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| `_tag` | `RecipientAcceptOperatorSend` | Dummy callback to prevent invalid recipient contract. | `initiator`: `ByStr20`, `sender` : `ByStr20`, `recipient`: `ByStr20`, `amount`: `Uint128`, where `initiator` is the address of an operator,`sender` is the address of the token_owner, `recipient` is the address of the recipient, and `amount` is the amount of fungible tokens to be transferred. |
+| `_tag` | `OperatorSendSuccessCallBack` | Provide the sender the status of the transfer.        | `initiator`: `ByStr20`, `sender` : `ByStr20`, `recipient`: `ByStr20`, `amount`: `Uint128`, where `initiator` is the address of an operator,`sender` is the address of the token_owner, `recipient` is the address of the recipient, and `amount` is the amount of fungible tokens to be transferred. |
+
+**Events/Errors:**
+
+|              | Name                  | Description                | Event Parameters                                                                                                                                                                                                                                           |
+| ------------ | --------------------- | -------------------------- | ---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| `_eventname` | `OperatorSendSuccess` | Sending is successful.     | `initiator`: `ByStr20` which is the operator's address, `sender`: `ByStr20` which is the token_owner's address, `recipient`: `ByStr20` which is the recipient's address, and `amount`: `Uint128` which is the amount of fungible tokens to be transferred. |
+| `_eventname` | `Error`               | Sending is not successful. | - emit `CodeNotApprovedOperator` if sender is not an approved operator for the token_owner <br> - emit `CodeInsufficientFunds` if the balance of the token_owner is lesser than the specified amount that is to be transferred.                            |
 
 ## V. Existing Implementation(s)
 
 - [ZRC2 Reference contract](../reference/FungibleToken.scilla)
+- [ZRC2-Mintable Reference contract](../reference/FungibleToken-Mintable.scilla)
 - [ZRC2-Operator Reference contract](../reference/FungibleToken-Operator.scilla)
 
 To test the reference contract, simply go to the [`example`](../example) folder and run one of the JS scripts. For example, to deploy the contract, run:


### PR DESCRIPTION
Making `operator` and `default_operator` roles **Optional** in ZRC-2 Fungible token standard.