### PR TITLE
feat(zrc2): Make minting token_ids automatic

### DIFF
--- a/example/zrc1/mint.js
+++ b/example/zrc1/mint.js
@@ -31,12 +31,7 @@ async function main() {
                     vname: 'to',
                     type: 'ByStr20',
                     value: `${address}`,
-                },
-                {
-                    vname: 'token_id',
-                    type: 'Uint256',
-                    value: '2',
-                },
+                }
                 {
                     vname: 'token_uri',
                     type: 'String',

--- a/reference/nonfungible-token.scilla
+++ b/reference/nonfungible-token.scilla
@@ -339,21 +339,22 @@ end
 
 (* @dev:    Mint new tokens. Only minters can mint.           *)
 (* @param:  to        - Address of the token recipient        *)
-(* @param:  token_id  - ID of the new token to be minted      *)
 (* @param:  token_uri - URI of the the new token to be minted *)
-transition Mint(to: ByStr20, token_id: Uint256, token_uri: String)
-  IsTokenExists token_id;
-  IsMinter _sender;
-  (* Mint new token *)
-  token_owners[token_id] := to;
+transition Mint(to: ByStr20, token_uri: String)
   (* Add to owner count *)
   UpdateTokenCount add_operation to;
-  (* Add token_uri for token_id *)
-  token_uris[token_id] := token_uri;
   (* Add to total_supply *)
   current_supply <- total_supply;
   new_supply = builtin add current_supply one;
-  total_supply := new_supply; 
+  total_supply := new_supply;
+  (* Initiate token_id and check conditions *)
+  token_id = new_supply;
+  IsMinter _sender;
+  IsTokenExists token_id;
+  (* Mint new non-fungible token *)
+  token_owners[token_id] := to;
+  (* Add token_uri for token_id *)
+  token_uris[token_id] := token_uri;
   e = {_eventname: "MintSuccess"; by: _sender; recipient: to;
         token_id: token_id; token_uri: token_uri};
   event e;

--- a/zrcs/zrc-1.md
+++ b/zrcs/zrc-1.md
@@ -236,7 +236,6 @@ transition ConfigureMinter(minter: ByStr20)
 ```ocaml
 (* @dev:    Mint new tokens. Only minters can mint.           *)
 (* @param:  to        - Address of the token recipient        *)
-(* @param:  token_id  - ID of the new token to be minted      *)
 (* @param:  token_uri - URI of the the new token to be minted *)
 transition Mint(to: ByStr20, token_id: Uint256, token_uri: String)
 ```
@@ -246,7 +245,6 @@ transition Mint(to: ByStr20, token_id: Uint256, token_uri: String)
 |        | Name        | Type      | Description                                       |
 | ------ | ----------- | --------- | ------------------------------------------------- |
 | @param | `to`        | `ByStr20` | Address of the recipient of the NFT to be minted. |
-| @param | `token_id`  | `Uint256` | Unique token_id of the NFT to be minted.          |
 | @param | `token_uri` | `Uint256` | Token URI of the NFT to be minted.                |
 
 **Messages sent:**


### PR DESCRIPTION
- Remove `token_id` input in the transition `Mint()`
- Add automatic `token_id` counter using `total_supply + 1` in transition `Mint()`