### PR TITLE
chore(zrc5): transit zrc5 to approved

### DIFF
--- a/zrcs/zrc-5.md
+++ b/zrcs/zrc-5.md
@@ -1,6 +1,6 @@
 | ZRC | Title                        | Status   | Type     | Author                                                                                                                       | Created (yyyy-mm-dd) | Updated (yyyy-mm-dd) |
 | --- | ---------------------------- | -------- | -------- | ---------------------------------------------------------------------------------------------------------------------------- | -------------------- | -------------------- |
-| 5   | Convention for Deposit of ZIL | Draft | Standard | Jun Hao Tan <junhao@zilliqa.com> | 2020-06-25           | 2020-06-25           |
+| 5   | Convention for Deposit of ZIL | Approved | Standard | Jun Hao Tan <junhao@zilliqa.com> | 2020-06-25           | 2020-06-25           |
 
 ## I. What is ZIL?
 


### PR DESCRIPTION
This is now a standard convention. Hence, transiting the status to approved. Long overdue