### PR TITLE
Dead code and some syntax fixes

### DIFF
--- a/reference/multisig_wallet.scilla
+++ b/reference/multisig_wallet.scilla
@@ -1,6 +1,6 @@
 scilla_version 0
 
-import ListUtils IntUtils BoolUtils
+import ListUtils BoolUtils
 
 (***************************************************)
 (*               Associated library                *)

--- a/reference/multisig_wallet.scilla
+++ b/reference/multisig_wallet.scilla
@@ -7,10 +7,6 @@ import ListUtils BoolUtils
 (***************************************************)
 library WalletLib
 
-(* Event emitted when the contract is initialized *)
-let mk_contract_initialized_event =
-  { _eventname : "Contract initialized" }
-
 (* Event for communicating a new transaction id *)
 let mk_transaction_added_event =
   fun (tc : Uint32) =>

--- a/zrcs/zrc-5.md
+++ b/zrcs/zrc-5.md
@@ -42,7 +42,7 @@ This is a sample implementation of `AddFunds` transition that unconditionally ac
 
 ```
 transition AddFunds ()
-  accept;
+  accept
 end
 ```
 


### PR DESCRIPTION
The issues fixed in `multisig_wallet.scilla` are discovered using @tramhnt99's dead code detector recently merged in Scilla's master. There is one more unused library entry (`f`) in `multisig_wallet.scilla` but I'd prefer to remove it along with some refactoring of the map insertion code (switch `Bool` with `Unit` type, like in the Fungible Token contract).