### PR TITLE
chore: gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,4 +1,2 @@
-example/zrc2/node_modules
-example/zrc4/node_modules
-example/zrc1/node_modules
-
+node_modules
+.DS_Store


### PR DESCRIPTION
This PR ignores `node_modules` and `.DS_Store`.

Previously, `node_modules` were ignored by `example/zrcX/node_modules`. Therefore whenever someone try to add a new ZRC example, `.gitignore` should be updated as well. This PR removes the unnecessary work.