### PR TITLE
refactor(zrc1): remove unnecessary validation

### DIFF
--- a/reference/nonfungible-token.scilla
+++ b/reference/nonfungible-token.scilla
@@ -144,16 +144,6 @@ procedure IsNotSelf(address_a: ByStr20, address_b: ByStr20)
   end
 end
 
-procedure IsTokenNotFound(token_id: Uint256)
-  token_exist <- exists token_owners[token_id];
-  match token_exist with
-  | False =>
-  | True =>
-    err = CodeTokenExists;
-    ThrowError err
-  end
-end
-
 procedure IsMinter(address: ByStr20)
   is_minter <- exists minters[address];
   match is_minter with
@@ -363,7 +353,7 @@ procedure Minting(input_pair: Pair ByStr20 String)
   new_token_id_count = builtin add current_token_id_count one;
   token_id_count := new_token_id_count;
   token_id = new_token_id_count;
-  IsTokenNotFound token_id;
+
   (* Mint new non-fungible token *)
   token_owners[token_id] := to;
   (* Add token_uri for token_id *)


### PR DESCRIPTION
https://github.com/Zilliqa/ZRC/blob/master/reference/nonfungible-token.scilla#L349-L374
```ocaml
  current_token_id_count <- token_id_count;
  new_token_id_count = builtin add current_token_id_count one;
  token_id_count := new_token_id_count;
  token_id = new_token_id_count;
  IsTokenNotFound token_id;
  (* Mint new non-fungible token *)
  token_owners[token_id] := to;
```
Because of the above logic, `IsTokenNotFound()` will never throw an error. Also, `IsTokenNotFound` is only used for above.
```ocaml
procedure IsTokenNotFound(token_id: Uint256)
  token_exist <- exists token_owners[token_id];
  match token_exist with
  | False =>
  | True =>
    err = CodeTokenExists;
    ThrowError err
  end
end
```

Therefore, we can remove `IsTokenNotFound()` and simplify the logic in `Minting()`.