### PR TITLE
feat(zrc6): validate destination for Minting

### DIFF
--- a/reference/zrc6.scilla
+++ b/reference/zrc6.scilla
@@ -348,9 +348,13 @@ end
 
 (* @Requirements: *)
 (* - The contract must not be paused. Otherwise, it must throw `PausedError` *)
+(* - `to` must not be the zero address. Otherwise, it must throw `ZeroAddressDestinationError` *)
+(* - `to` must not be `_this_address`. Otherwise, it must throw `ThisAddressDestinationError` *)
 (* - `_sender` must be a minter. Otherwise, it must throw `NotMinterError` *)
 procedure MintToken(to: ByStr20)
   RequireNotPaused;
+  RequireValidDestination to;
+
   IsMinter _sender;
 
   (* generate ID *)

--- a/tests/zrc6/zrc6.mint.test.ts
+++ b/tests/zrc6/zrc6.mint.test.ts
@@ -258,6 +258,26 @@ describe("Minter", () => {
 describe("Mint & Burn", () => {
   const testCases = [
     {
+      name: "throws ZeroAddressDestinationError",
+      transition: "Mint",
+      getSender: () => getTestAddr(STRANGER),
+      getParams: () => ({
+        to: "0x0000000000000000000000000000000000000000",
+      }),
+      error: ZRC6_ERROR.ZeroAddressDestinationError,
+      want: undefined,
+    },
+    {
+      name: "throws ThisAddressDestinationError",
+      transition: "Mint",
+      getSender: () => getTestAddr(STRANGER),
+      getParams: () => ({
+        to: globalContractAddress,
+      }),
+      error: ZRC6_ERROR.ThisAddressDestinationError,
+      want: undefined,
+    },
+    {
       name: "throws NotMinterError",
       transition: "Mint",
       getSender: () => getTestAddr(STRANGER),

--- a/zrcs/zrc-6.md
+++ b/zrcs/zrc-6.md
@@ -307,6 +307,8 @@ Mints a token and transfers it to `to`.
 **Requirements:**
 
 - The contract must not be paused. Otherwise, it must throw `PausedError`.
+- `to` must not be the zero address. Otherwise, it must throw `ZeroAddressDestinationError`
+- `to` must not be `_this_address`. Otherwise, it must throw `ThisAddressDestinationError`
 - `_sender` must be a minter. Otherwise, it must throw `NotMinterError`.
 
 **Messages:**
@@ -335,6 +337,8 @@ Mints tokens and transfers them to `to_list`.
 **Requirements:**
 
 - The contract must not be paused. Otherwise, it must throw `PausedError`.
+- `to` must not be the zero address. Otherwise, it must throw `ZeroAddressDestinationError`
+- `to` must not be `_this_address`. Otherwise, it must throw `ThisAddressDestinationError`
 - `_sender` must be a minter. Otherwise, it must throw `NotMinterError`.
 
 **Messages:**


### PR DESCRIPTION
## Description
This PR validates the destination for minting.

The destination must not be zero address or `_this_address`

## References
- [Ethereum Smart Contract Best Practices - Token Implementation Best Practice](https://github.com/ConsenSys/smart-contract-best-practices/blob/master/docs/tokens.md)
