### PR TITLE
test: use json params util

### DIFF
--- a/tests/zrc6/config.ts
+++ b/tests/zrc6/config.ts
@@ -2,14 +2,12 @@ import { bytes, units } from "@zilliqa-js/util";
 import fs from "fs";
 import { Long, BN } from "@zilliqa-js/util";
 
-export const CONTAINER = process.env["CONTAINER"];
-
 export const API = `http://localhost:${process.env["PORT"]}`; // Zilliqa Isolated Server
 export const CHAIN_ID = 222;
 export const MSG_VERSION = 1;
 export const VERSION = bytes.pack(CHAIN_ID, MSG_VERSION);
 
-export const CODE_PATH = "reference/zrc6.scilla";
+const CODE_PATH = "reference/zrc6.scilla";
 export const CODE = fs.readFileSync(CODE_PATH).toString();
 
 export const ZRC6_ERROR = {

--- a/tests/zrc6/testutils.test.ts
+++ b/tests/zrc6/testutils.test.ts
@@ -1,4 +1,4 @@
-import { extractTypes, getJSONValue } from "./testutil";
+import { extractTypes, getJSONParams, getJSONValue } from "./testutil";
 
 describe("extractTypes", () => {
   const testCases = [
@@ -149,6 +149,41 @@ describe("getJSONValue", () => {
     const { value, type, want } = testCase;
     it(type, () => {
       const res = getJSONValue(value, type);
+      expect(JSON.stringify(res)).toBe(JSON.stringify(want));
+    });
+  }
+});
+
+describe("getJSONParams", () => {
+  const testCases = [
+    {
+      param: {},
+      want: [],
+    },
+    {
+      param: {
+        x: ["ByStr20", "0x0000000000000000000000000000000000000000"],
+        y: ["Uint256", 1],
+      },
+      want: [
+        {
+          type: "ByStr20",
+          value: "0x0000000000000000000000000000000000000000",
+          vname: "x",
+        },
+        {
+          type: "Uint256",
+          value: "1",
+          vname: "y",
+        },
+      ],
+    },
+  ];
+
+  for (const testCase of testCases) {
+    const { param, want } = testCase;
+    it(JSON.stringify(param), () => {
+      const res = getJSONParams(param);
       expect(JSON.stringify(res)).toBe(JSON.stringify(want));
     });
   }


### PR DESCRIPTION
## Description
This PR uses `getJSONParams` instead of `useContractInfo`.
In this way, test cases are more consistent and readable. 
Also, it removes Scilla Checker dependency.