### PR TITLE
feat: multiple events for batch ops

### DIFF
--- a/reference/zrc6.scilla
+++ b/reference/zrc6.scilla
@@ -414,7 +414,14 @@ procedure BurnToken(token_id: Uint256)
     (* subtract one from the total supply *)
     current_supply <- total_supply;
     new_supply = builtin sub current_supply one;
-    total_supply := new_supply
+    total_supply := new_supply;
+
+    e = {
+      _eventname: "Burn";
+      token_owner: token_owner;
+      token_id: token_id
+    };
+    event e
   end
 end
 
@@ -444,7 +451,15 @@ procedure TransferToken(to: ByStr20, token_id: Uint256)
     (* subtract one from previous token owner balance *)
     UpdateBalance sub_operation token_owner;
     (* add one to the new token owner balance *)
-    UpdateBalance add_operation to
+    UpdateBalance add_operation to;
+
+    e = {
+      _eventname: "TransferFrom"; 
+      from: token_owner;
+      to: to;
+      token_id: token_id
+    };
+    event e
   end
 end
 
@@ -660,12 +675,6 @@ transition Burn(token_id: Uint256)
     Throw error
   | Some token_owner =>
     BurnToken token_id;
-    e = {
-      _eventname: "Burn";
-      token_owner: token_owner;
-      token_id: token_id
-    };
-    event e;
     msg_to_sender = {
       _tag: "ZRC6_BurnCallback";
       _recipient: _sender;
@@ -685,11 +694,6 @@ end
 transition BatchBurn(token_id_list: List Uint256)
   RequireNotPaused;
   forall token_id_list BurnToken;
-  e = {
-    _eventname: "BatchBurn";
-    token_id_list: token_id_list
-  };
-  event e;
   msg_to_sender = {
     _tag: "ZRC6_BatchBurnCallback";
     _recipient: _sender;
@@ -894,13 +898,6 @@ transition TransferFrom(to: ByStr20, token_id: Uint256)
     Throw error
   | Some token_owner =>
     TransferToken to token_id;
-    e = {
-      _eventname: "TransferFrom"; 
-      from: token_owner;
-      to: to;
-      token_id: token_id
-    };
-    event e;
     msg_to_recipient = {
       _tag: "ZRC6_RecipientAcceptTransferFrom";
       _recipient: to;
@@ -929,11 +926,6 @@ end
 transition BatchTransferFrom(to_token_id_pair_list: List (Pair ByStr20 Uint256))
   RequireNotPaused;
   forall to_token_id_pair_list HandleTransfer;
-  e = {
-    _eventname: "BatchTransferFrom"; 
-    to_token_id_pair_list: to_token_id_pair_list
-  };
-  event e;
   msg_to_sender = {
     _tag: "ZRC6_BatchTransferFromCallback";
     _recipient: _sender;

--- a/tests/zrc6/zrc6.approval.test.ts
+++ b/tests/zrc6/zrc6.approval.test.ts
@@ -710,16 +710,28 @@ describe("Approval", () => {
         },
         events: [
           {
-            name: "BatchTransferFrom",
+            name: "TransferFrom",
             getParams: () => ({
-              to_token_id_pair_list: [
-                "List (Pair (ByStr20) (Uint256))",
-                [
-                  [getTestAddr(TOKEN_OWNER_A), 2],
-                  [getTestAddr(STRANGER_A), 3],
-                  [getTestAddr(STRANGER_A), 4],
-                ],
-              ],
+              from: ["ByStr20", getTestAddr(TOKEN_OWNER_B)],
+              to: ["ByStr20", getTestAddr(STRANGER_A)],
+              token_id: ["Uint256", 4],
+            }),
+          },
+
+          {
+            name: "TransferFrom",
+            getParams: () => ({
+              from: ["ByStr20", getTestAddr(TOKEN_OWNER_B)],
+              to: ["ByStr20", getTestAddr(STRANGER_A)],
+              token_id: ["Uint256", 3],
+            }),
+          },
+          {
+            name: "TransferFrom",
+            getParams: () => ({
+              from: ["ByStr20", getTestAddr(TOKEN_OWNER_B)],
+              to: ["ByStr20", getTestAddr(TOKEN_OWNER_A)],
+              token_id: ["Uint256", 2],
             }),
           },
         ],

--- a/tests/zrc6/zrc6.mint.test.ts
+++ b/tests/zrc6/zrc6.mint.test.ts
@@ -597,9 +597,24 @@ describe("Mint & Burn", () => {
         },
         events: [
           {
-            name: "BatchBurn",
+            name: "Burn",
             getParams: () => ({
-              token_id_list: ["List (Uint256)", [1, 2, 3]],
+              token_owner: ["ByStr20", getTestAddr(CONTRACT_OWNER)],
+              token_id: ["Uint256", 3],
+            }),
+          },
+          {
+            name: "Burn",
+            getParams: () => ({
+              token_owner: ["ByStr20", getTestAddr(CONTRACT_OWNER)],
+              token_id: ["Uint256", 2],
+            }),
+          },
+          {
+            name: "Burn",
+            getParams: () => ({
+              token_owner: ["ByStr20", getTestAddr(CONTRACT_OWNER)],
+              token_id: ["Uint256", 1],
             }),
           },
         ],

--- a/zrcs/zrc-6.md
+++ b/zrcs/zrc-6.md
@@ -409,9 +409,7 @@ Destroys `token_id_list`.
 
 **Events:**
 
-|              | Name        | Description                       | Event Parameters                                                                   |
-| ------------ | ----------- | --------------------------------- | ---------------------------------------------------------------------------------- |
-| `_eventname` | `BatchBurn` | Multiple tokens have been burned. | `token_id_list` : `List Uint256`<br/>List of unique IDs of the NFT to be destroyed |
+Equivalent to multiple [`Burn`](#8-burn-optional) events.
 
 #### 10. `AddMinter`
 
@@ -611,9 +609,7 @@ Transfers multiple `token_id` to multiple `to`.
 
 **Events:**
 
-|              | Name                | Description                            | Event Parameters                                                                                                                                                                                                                  |
-| ------------ | ------------------- | -------------------------------------- | --------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
-| `_eventname` | `BatchTransferFrom` | Multiple tokens have been transferred. | `to_token_id_pair_list` : `List (Pair ByStr20 Uint256)` <br/><br/> List of Pair (`to`, `token_id`)<br/><br/><ul><li>`to` : `ByStr20`<br/>Address of a recipient</li><li>`token_id` : `Uint256`<br/>Unique ID of a token</li></ul> |
+Equivalent to multiple [`TransferFrom`](#15-transferfrom) events.
 
 #### 17. `SetContractOwnershipRecipient` (Optional)
 


### PR DESCRIPTION
This PR changes `BatchBurn`, `BatchTransferFrom` to emit an event per item to include the previous token owner address in the event. It's more complete and consistent because `Burn` and `TransferFrom` events provide the previous token owner address.


|  N  | Current BatchBurn (cumulative_gas) | New BatchBurn with Multiple Events (cumulative_gas) |
| :-: | ---------------------------------- | --------------------------------------------------- |
| 10  | 766                                | 885                                                 |
| 50  | 2137                               | 2766                                                |
| 100 | 3843                               | 5110                                                |


This approach is more gas-efficient way, compared to the approach #137 with single event.
