### PR TITLE
docs(zrc-6): event -> exception

### DIFF
--- a/zrcs/zrc-6.md
+++ b/zrcs/zrc-6.md
@@ -126,7 +126,7 @@ The main advantages of this standard are:
 
 ### D. Error Codes
 
-The NFT contract must define the following constants for use as error codes for the `Error` event.
+The NFT contract must define the following constants for use as error codes for the `Error` exception.
 
 | Name                                 | Type    |  Code | Description                                                          | Required |
 | ------------------------------------ | ------- | ----: | -------------------------------------------------------------------- | :------: |


### PR DESCRIPTION
This PR fixes the Error Code description by replacing `Error event` -> `Error exception`.

scilla-doc explains error event with the following example.
https://scilla.readthedocs.io/en/latest/scilla-by-example.html?highlight=error%20event%20#procedures
```
procedure DonationEvent (failure : Bool, error_code : Int32)
  match failure with
  | False =>
    e = {_eventname : "DonationSuccess"; donor : _sender;
         amount : _amount; code : accepted_code};
    event e
  | True =>
    e = {_eventname : "DonationFailure"; donor : _sender;
         amount : _amount; code : error_code};
    event e
  end
end
```