### PR TITLE
docs(zrc-1): event -> exception

### DIFF
--- a/zrcs/zrc-1.md
+++ b/zrcs/zrc-1.md
@@ -35,7 +35,7 @@ The NFT contract specification describes:
 
 ### B. Error Codes
 
-The NFT contract must define the following constants for use as error codes for the `Error` event.
+The NFT contract must define the following constants for use as error codes for the `Error` exception.
 
 | Name                               | Type    | Code  | Description                                                                         |
 | ---------------------------------- | ------- | ----- | ----------------------------------------------------------------------------------- |


### PR DESCRIPTION
This PR fixes the Error Code description by replacing `Error event` -> `Error exception`.
