### PR TITLE
small fix to delete token_uris on burn

### DIFF
--- a/reference/zrc6.scilla
+++ b/reference/zrc6.scilla
@@ -407,6 +407,7 @@ procedure BurnToken(token_id: Uint256)
     RequireOwnerOrOperator token_owner;
     (* Destroy existing token *)
     delete token_owners[token_id];
+    delete token_uris[token_id];
     delete spenders[token_id];
 
     (* subtract one from the balance *)


### PR DESCRIPTION
Small bug fix to to reference ZRC6 implementation to delete `token_uris` of a burnt token