### PR TITLE
feat(zrc6): token_owner param

### DIFF
--- a/reference/zrc6.scilla
+++ b/reference/zrc6.scilla
@@ -800,6 +800,7 @@ transition SetSpender(spender: ByStr20, token_id: Uint256)
 
     e = {
       _eventname: "SetSpender";
+      token_owner: token_owner;
       spender: spender;
       token_id: token_id
     };
@@ -808,6 +809,7 @@ transition SetSpender(spender: ByStr20, token_id: Uint256)
       _tag: "ZRC6_SetSpenderCallback";
       _recipient: _sender;
       _amount: Uint128 0;
+      token_owner: token_owner;
       spender: spender;
       token_id: token_id
     };
@@ -845,6 +847,7 @@ transition AddOperator(operator: ByStr20)
     end;
     e = {
       _eventname: "AddOperator";
+      token_owner: _sender;
       operator: operator
     };
     event e;
@@ -852,6 +855,7 @@ transition AddOperator(operator: ByStr20)
       _tag: "ZRC6_AddOperatorCallback";
       _recipient: _sender;
       _amount: Uint128 0;
+      token_owner: _sender;
       operator: operator
     };
     msgs = one_msg msg_to_sender;
@@ -874,6 +878,7 @@ transition RemoveOperator(operator: ByStr20)
   end;
   e = {
     _eventname: "RemoveOperator";
+    token_owner: _sender;
     operator: operator
   };
   event e;
@@ -881,6 +886,7 @@ transition RemoveOperator(operator: ByStr20)
     _tag: "ZRC6_RemoveOperatorCallback";
     _recipient: _sender;
     _amount: Uint128 0;
+    token_owner: _sender;
     operator: operator
   };
   msgs = one_msg msg_to_sender;

--- a/tests/zrc6/zrc6.approval.test.ts
+++ b/tests/zrc6/zrc6.approval.test.ts
@@ -207,6 +207,7 @@ describe("Approval", () => {
           {
             name: "SetSpender",
             getParams: () => ({
+              token_owner: ["ByStr20", getTestAddr(TOKEN_OWNER_A)],
               spender: ["ByStr20", getTestAddr(STRANGER_A)],
               token_id: ["Uint256", 1],
             }),
@@ -216,6 +217,7 @@ describe("Approval", () => {
           {
             tag: "ZRC6_SetSpenderCallback",
             getParams: () => ({
+              token_owner: ["ByStr20", getTestAddr(TOKEN_OWNER_A)],
               spender: ["ByStr20", getTestAddr(STRANGER_A)],
               token_id: ["Uint256", 1],
             }),
@@ -240,6 +242,7 @@ describe("Approval", () => {
           {
             name: "SetSpender",
             getParams: () => ({
+              token_owner: ["ByStr20", getTestAddr(TOKEN_OWNER_A)],
               spender: ["ByStr20", ZERO_ADDRESS],
               token_id: ["Uint256", 1],
             }),
@@ -249,6 +252,7 @@ describe("Approval", () => {
           {
             tag: "ZRC6_SetSpenderCallback",
             getParams: () => ({
+              token_owner: ["ByStr20", getTestAddr(TOKEN_OWNER_A)],
               spender: ["ByStr20", ZERO_ADDRESS],
               token_id: ["Uint256", 1],
             }),
@@ -306,6 +310,7 @@ describe("Approval", () => {
           {
             name: "AddOperator",
             getParams: () => ({
+              token_owner: ["ByStr20", getTestAddr(TOKEN_OWNER_A)],
               operator: ["ByStr20", getTestAddr(STRANGER_A)],
             }),
           },
@@ -314,6 +319,7 @@ describe("Approval", () => {
           {
             tag: "ZRC6_AddOperatorCallback",
             getParams: () => ({
+              token_owner: ["ByStr20", getTestAddr(TOKEN_OWNER_A)],
               operator: ["ByStr20", getTestAddr(STRANGER_A)],
             }),
           },
@@ -360,6 +366,7 @@ describe("Approval", () => {
           {
             name: "RemoveOperator",
             getParams: () => ({
+              token_owner: ["ByStr20", getTestAddr(TOKEN_OWNER_A)],
               operator: ["ByStr20", getTestAddr(OPERATOR)],
             }),
           },
@@ -368,6 +375,7 @@ describe("Approval", () => {
           {
             tag: "ZRC6_RemoveOperatorCallback",
             getParams: () => ({
+              token_owner: ["ByStr20", getTestAddr(TOKEN_OWNER_A)],
               operator: ["ByStr20", getTestAddr(OPERATOR)],
             }),
           },

--- a/zrcs/zrc-6.md
+++ b/zrcs/zrc-6.md
@@ -487,7 +487,7 @@ Sets `spender` for `token_id`. To remove `spender` for a token, use `zero_addres
 
 |        | Name                      | Description                                                 | Callback Parameters                                                                                                                                                                                |
 | ------ | ------------------------- | ----------------------------------------------------------- | -------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
-| `_tag` | `ZRC6_AddSpenderCallback` | Provide the sender the address of the spender and token ID. | <ul><li>`token_owner` : `ByStr20`<br/>Address of the token owner</li><li>`spender` : `ByStr20`<br/>Address that has been updated</li><li>`token_id` : `Uint256`</br>Unique ID of a token</li></ul> |
+| `_tag` | `ZRC6_SetSpenderCallback` | Provide the sender the address of the spender and token ID. | <ul><li>`token_owner` : `ByStr20`<br/>Address of the token owner</li><li>`spender` : `ByStr20`<br/>Address that has been updated</li><li>`token_id` : `Uint256`</br>Unique ID of a token</li></ul> |
 
 **Events:**
 

--- a/zrcs/zrc-6.md
+++ b/zrcs/zrc-6.md
@@ -1,6 +1,6 @@
 | ZRC | Title                       |  Status  |   Type   | Author                                                                      | Created (yyyy-mm-dd) | Updated (yyyy-mm-dd) |
 | :-: | :-------------------------- | :------: | :------: | :-------------------------------------------------------------------------- | :------------------: | :------------------: |
-|  6  | Non-Fungible Token Standard | Approved | Standard | Neuti Yoo<br/><noel@zilliqa.com> <br/> Jun Hao Tan<br/><junhao@zilliqa.com> |      2021-10-01      |      2022-01-05      |
+|  6  | Non-Fungible Token Standard | Approved | Standard | Neuti Yoo<br/><noel@zilliqa.com> <br/> Jun Hao Tan<br/><junhao@zilliqa.com> |      2021-10-01      |      2022-02-04      |
 
 ## Table of Contents
 

--- a/zrcs/zrc-6.md
+++ b/zrcs/zrc-6.md
@@ -485,15 +485,15 @@ Sets `spender` for `token_id`. To remove `spender` for a token, use `zero_addres
 
 **Messages:**
 
-|        | Name                      | Description                                                 | Callback Parameters                                                                                                               |
-| ------ | ------------------------- | ----------------------------------------------------------- | --------------------------------------------------------------------------------------------------------------------------------- |
-| `_tag` | `ZRC6_AddSpenderCallback` | Provide the sender the address of the spender and token ID. | <ul><li>`spender` : `ByStr20`<br/>Address that has been updated</li><li>`token_id` : `Uint256`</br>Unique ID of a token</li></ul> |
+|        | Name                      | Description                                                 | Callback Parameters                                                                                                                                                                                |
+| ------ | ------------------------- | ----------------------------------------------------------- | -------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| `_tag` | `ZRC6_AddSpenderCallback` | Provide the sender the address of the spender and token ID. | <ul><li>`token_owner` : `ByStr20`<br/>Address of the token owner</li><li>`spender` : `ByStr20`<br/>Address that has been updated</li><li>`token_id` : `Uint256`</br>Unique ID of a token</li></ul> |
 
 **Events:**
 
-|              | Name         | Description               | Event Parameters                                                                                                                  |
-| ------------ | ------------ | ------------------------- | --------------------------------------------------------------------------------------------------------------------------------- |
-| `_eventname` | `SetSpender` | Spender has been updated. | <ul><li>`spender` : `ByStr20`<br/>Address that has been updated</li><li>`token_id` : `Uint256`</br>Unique ID of a token</li></ul> |
+|              | Name         | Description               | Event Parameters                                                                                                                                                                                   |
+| ------------ | ------------ | ------------------------- | -------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| `_eventname` | `SetSpender` | Spender has been updated. | <ul><li>`token_owner` : `ByStr20`<br/>Address of the token owner</li><li>`spender` : `ByStr20`<br/>Address that has been updated</li><li>`token_id` : `Uint256`</br>Unique ID of a token</li></ul> |
 
 #### 13. `AddOperator`
 
@@ -513,15 +513,15 @@ Adds `operator` for `_sender`.
 
 **Messages:**
 
-|        | Name                       | Description                                     | Callback Parameters                                    |
-| ------ | -------------------------- | ----------------------------------------------- | ------------------------------------------------------ |
-| `_tag` | `ZRC6_AddOperatorCallback` | Provide the sender the address of the operator. | `operator` : `ByStr20`<br/>Address that has been added |
+|        | Name                       | Description                                     | Callback Parameters                                                                                                                       |
+| ------ | -------------------------- | ----------------------------------------------- | ----------------------------------------------------------------------------------------------------------------------------------------- |
+| `_tag` | `ZRC6_AddOperatorCallback` | Provide the sender the address of the operator. | <ul><li>`token_owner` : `ByStr20`<br/>Address of the token owner</li><li>`operator` : `ByStr20`<br/>Address that has been added</li></ul> |
 
 **Events:**
 
-|              | Name          | Description              | Event Parameters                                                         |
-| ------------ | ------------- | ------------------------ | ------------------------------------------------------------------------ |
-| `_eventname` | `AddOperator` | Operator has been added. | <ul><li>`operator` : `ByStr20`<br/>Address that has been added</li></ul> |
+|              | Name          | Description              | Event Parameters                                                                                                                          |
+| ------------ | ------------- | ------------------------ | ----------------------------------------------------------------------------------------------------------------------------------------- |
+| `_eventname` | `AddOperator` | Operator has been added. | <ul><li>`token_owner` : `ByStr20`<br/>Address of the token owner</li><li>`operator` : `ByStr20`<br/>Address that has been added</li></ul> |
 
 #### 14. `RemoveOperator`
 
@@ -539,15 +539,15 @@ Removes `operator` for `_sender`.
 
 **Messages:**
 
-|        | Name                          | Description                                           | Callback Parameters                                      |
-| ------ | ----------------------------- | ----------------------------------------------------- | -------------------------------------------------------- |
-| `_tag` | `ZRC6_RemoveOperatorCallback` | Provide the sender the address that has been removed. | `operator` : `ByStr20`<br/>Address that has been removed |
+|        | Name                          | Description                                           | Callback Parameters                                                                                                                         |
+| ------ | ----------------------------- | ----------------------------------------------------- | ------------------------------------------------------------------------------------------------------------------------------------------- |
+| `_tag` | `ZRC6_RemoveOperatorCallback` | Provide the sender the address that has been removed. | <ul><li>`token_owner` : `ByStr20`<br/>Address of the token owner</li><li>`operator` : `ByStr20`<br/>Address that has been removed</li></ul> |
 
 **Events:**
 
-|              | Name             | Description                | Event Parameters                                                           |
-| ------------ | ---------------- | -------------------------- | -------------------------------------------------------------------------- |
-| `_eventname` | `RemoveOperator` | Operator has been removed. | <ul><li>`operator` : `ByStr20`<br/>Address that has been removed</li></ul> |
+|              | Name             | Description                | Event Parameters                                                                                                                            |
+| ------------ | ---------------- | -------------------------- | ------------------------------------------------------------------------------------------------------------------------------------------- |
+| `_eventname` | `RemoveOperator` | Operator has been removed. | <ul><li>`token_owner` : `ByStr20`<br/>Address of the token owner</li><li>`operator` : `ByStr20`<br/>Address that has been removed</li></ul> |
 
 #### 15. `TransferFrom`
 


### PR DESCRIPTION
This PR includes `token_owner` as callback and event parameter for the following transitions:
- `SetSpender`
- `AddOperator`
- `RemoveOperator`

Also, it fixes the `SetSpender` callback name (`ZRC6_AddSpenderCallback`  -> `ZRC6_SetSpenderCallback`).