### PR TITLE
fix: callback param

### DIFF
--- a/reference/zrc6.scilla
+++ b/reference/zrc6.scilla
@@ -809,7 +809,6 @@ transition SetSpender(spender: ByStr20, token_id: Uint256)
       _tag: "ZRC6_SetSpenderCallback";
       _recipient: _sender;
       _amount: Uint128 0;
-      token_owner: token_owner;
       spender: spender;
       token_id: token_id
     };
@@ -855,7 +854,6 @@ transition AddOperator(operator: ByStr20)
       _tag: "ZRC6_AddOperatorCallback";
       _recipient: _sender;
       _amount: Uint128 0;
-      token_owner: _sender;
       operator: operator
     };
     msgs = one_msg msg_to_sender;
@@ -886,7 +884,6 @@ transition RemoveOperator(operator: ByStr20)
     _tag: "ZRC6_RemoveOperatorCallback";
     _recipient: _sender;
     _amount: Uint128 0;
-    token_owner: _sender;
     operator: operator
   };
   msgs = one_msg msg_to_sender;

--- a/tests/zrc6/zrc6.approval.test.ts
+++ b/tests/zrc6/zrc6.approval.test.ts
@@ -217,7 +217,6 @@ describe("Approval", () => {
           {
             tag: "ZRC6_SetSpenderCallback",
             getParams: () => ({
-              token_owner: ["ByStr20", getTestAddr(TOKEN_OWNER_A)],
               spender: ["ByStr20", getTestAddr(STRANGER_A)],
               token_id: ["Uint256", 1],
             }),
@@ -252,7 +251,6 @@ describe("Approval", () => {
           {
             tag: "ZRC6_SetSpenderCallback",
             getParams: () => ({
-              token_owner: ["ByStr20", getTestAddr(TOKEN_OWNER_A)],
               spender: ["ByStr20", ZERO_ADDRESS],
               token_id: ["Uint256", 1],
             }),
@@ -319,7 +317,6 @@ describe("Approval", () => {
           {
             tag: "ZRC6_AddOperatorCallback",
             getParams: () => ({
-              token_owner: ["ByStr20", getTestAddr(TOKEN_OWNER_A)],
               operator: ["ByStr20", getTestAddr(STRANGER_A)],
             }),
           },
@@ -375,7 +372,6 @@ describe("Approval", () => {
           {
             tag: "ZRC6_RemoveOperatorCallback",
             getParams: () => ({
-              token_owner: ["ByStr20", getTestAddr(TOKEN_OWNER_A)],
               operator: ["ByStr20", getTestAddr(OPERATOR)],
             }),
           },

--- a/zrcs/zrc-6.md
+++ b/zrcs/zrc-6.md
@@ -485,9 +485,9 @@ Sets `spender` for `token_id`. To remove `spender` for a token, use `zero_addres
 
 **Messages:**
 
-|        | Name                      | Description                                                 | Callback Parameters                                                                                                                                                                                |
-| ------ | ------------------------- | ----------------------------------------------------------- | -------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
-| `_tag` | `ZRC6_SetSpenderCallback` | Provide the sender the address of the spender and token ID. | <ul><li>`token_owner` : `ByStr20`<br/>Address of the token owner</li><li>`spender` : `ByStr20`<br/>Address that has been updated</li><li>`token_id` : `Uint256`</br>Unique ID of a token</li></ul> |
+|        | Name                      | Description                                                 | Callback Parameters                                                                                                               |
+| ------ | ------------------------- | ----------------------------------------------------------- | --------------------------------------------------------------------------------------------------------------------------------- |
+| `_tag` | `ZRC6_SetSpenderCallback` | Provide the sender the address of the spender and token ID. | <ul><li>`spender` : `ByStr20`<br/>Address that has been updated</li><li>`token_id` : `Uint256`</br>Unique ID of a token</li></ul> |
 
 **Events:**
 
@@ -513,9 +513,9 @@ Adds `operator` for `_sender`.
 
 **Messages:**
 
-|        | Name                       | Description                                     | Callback Parameters                                                                                                                       |
-| ------ | -------------------------- | ----------------------------------------------- | ----------------------------------------------------------------------------------------------------------------------------------------- |
-| `_tag` | `ZRC6_AddOperatorCallback` | Provide the sender the address of the operator. | <ul><li>`token_owner` : `ByStr20`<br/>Address of the token owner</li><li>`operator` : `ByStr20`<br/>Address that has been added</li></ul> |
+|        | Name                       | Description                                     | Callback Parameters                                    |
+| ------ | -------------------------- | ----------------------------------------------- | ------------------------------------------------------ |
+| `_tag` | `ZRC6_AddOperatorCallback` | Provide the sender the address of the operator. | `operator` : `ByStr20`<br/>Address that has been added |
 
 **Events:**
 
@@ -539,9 +539,9 @@ Removes `operator` for `_sender`.
 
 **Messages:**
 
-|        | Name                          | Description                                           | Callback Parameters                                                                                                                         |
-| ------ | ----------------------------- | ----------------------------------------------------- | ------------------------------------------------------------------------------------------------------------------------------------------- |
-| `_tag` | `ZRC6_RemoveOperatorCallback` | Provide the sender the address that has been removed. | <ul><li>`token_owner` : `ByStr20`<br/>Address of the token owner</li><li>`operator` : `ByStr20`<br/>Address that has been removed</li></ul> |
+|        | Name                          | Description                                           | Callback Parameters                                      |
+| ------ | ----------------------------- | ----------------------------------------------------- | -------------------------------------------------------- |
+| `_tag` | `ZRC6_RemoveOperatorCallback` | Provide the sender the address that has been removed. | `operator` : `ByStr20`<br/>Address that has been removed |
 
 **Events:**
 


### PR DESCRIPTION

## Description
For backward compatibility, this PR removes `token_owner` from callback params of the following transitions:
- `SetSpender`
- `AddOperator`
- `RemoveOperator`

## References
- #152 