### PR TITLE
ZRC - Introduce batching & "MetaClaim" (abstracting Transfer)

### DIFF
--- a/reference-contracts/MetaFungibleToken.scilla
+++ b/reference-contracts/MetaFungibleToken.scilla
@@ -3,7 +3,8 @@ scilla_version 0
 (***************************************************)
 (*               Associated library                *)
 (***************************************************)
-import IntUtils
+import IntUtils ListUtils
+
 library MetaFungibleToken
 
 let one_msg = 
@@ -41,10 +42,25 @@ let make_error =
     { _exception : "Error"; code : result_code }
   
 let zero = Uint128 0
+let two = Uint32 2
+let hash_length = Uint32 320
 let prefix = "0x"
 (* Dummy user-defined ADT *)
 type Unit =
 | Unit
+
+type Header =
+| Header of (Pair ByStr33 ByStr20)
+
+type Body =
+| Body of (Pair Uint128 Uint128)
+
+type Sig =
+| Sig of (Pair Uint128 ByStr64)
+
+type Cheque =
+| Cheque of Header Body Sig (* pubkey, to, amount, fee, nonce, sig *)
+(* ADTs (de)constructed for batching cheques. *)
 
 let get_val =
   fun (some_val: Option Uint128) =>
@@ -52,6 +68,56 @@ let get_val =
   | Some val => val
   | None => zero
   end
+  
+let map_fn = fun (cheque: Pair (Pair (Pair ByStr33 ByStr20) (Pair Uint128 Uint128)) (Pair Uint128 ByStr64)) =>
+  match cheque with
+  | Pair main tail =>
+    match main with
+    | Pair header body =>
+      match header with
+      | Pair pubkey to =>
+        match body with
+        | Pair amount fee =>
+          match tail with
+          | Pair nonce sig =>
+            let h = Header header in
+              let b = Body body in
+                let t = Sig tail in
+                  Cheque h b t
+          end
+        end
+      end
+    end
+  end
+
+let extract_from = 
+  fun (pubkey: ByStr33) => 
+    builtin schnorr_get_address pubkey
+    
+let hash_cheque =
+  fun (to: ByStr20) =>
+  fun (amount: Uint128) =>
+  fun (fee: Uint128) =>
+  fun (nonce:Uint128) =>
+  fun (signature: ByStr64) =>
+  fun (this_address: ByStr20) =>
+      let to_hash = builtin sha256hash to in
+      let amount_hash = builtin sha256hash amount in
+      let contract_hash = builtin sha256hash this_address in
+      let fee_hash = builtin sha256hash fee in
+      let nonce_hash = builtin sha256hash nonce in
+      let p0_hash = builtin concat to_hash amount_hash in
+      let p1_hash = builtin concat p0_hash contract_hash in
+      let p2_hash = builtin concat p1_hash fee_hash in
+      let p3_hash = builtin concat p2_hash nonce_hash in
+      builtin to_bystr p3_hash
+
+let rehash = 
+  fun (hash: ByStr) =>
+    let hash_str = builtin to_string hash in
+      let str = builtin substr hash_str two hash_length in
+        let rehashed = builtin sha256hash str in
+          builtin to_bystr rehashed
 
 (***************************************************)
 (*             The contract definition             *)
@@ -118,6 +184,120 @@ procedure AuthorizedMoveIfSufficientBalance(from: ByStr20, to: ByStr20, amount: 
     (* Balance not sufficient *)
     err = CodeInsufficientFunds;
     ThrowError err
+  end
+end
+
+procedure IsChequeValid(hash: ByStr)
+  cheque_invalid <- exists void_cheques[hash];
+  match cheque_invalid with
+  | True =>
+    err = CodeChequeVoid;
+    ThrowError err
+  | False =>
+  end
+end
+
+procedure IsValidSignature(pubkey: ByStr33, cheque_hash: ByStr, signature: ByStr64)
+  valid_sig = builtin schnorr_verify pubkey cheque_hash signature;
+  rehashed = rehash cheque_hash;
+  valid_sig_rehashed = builtin schnorr_verify pubkey rehashed signature; (* for ZilPay sigs *)
+  match valid_sig with
+  | True =>
+  | False =>
+    match valid_sig_rehashed with
+    | True =>
+    | False =>
+      err = CodeSignatureInvalid;
+      ThrowError err
+    end
+  end
+end
+
+procedure ValidateAndClaim(cheque: Cheque)
+  match cheque with
+  | Cheque head body tail =>
+    match head with
+    | Header (Pair pubkey to) =>
+      match body with
+      | Body (Pair amount fee) =>
+        match tail with
+        | Sig (Pair nonce signature) =>
+          hash = hash_cheque to amount fee nonce signature _this_address;
+          from = extract_from pubkey;
+          IsChequeValid hash;
+          IsValidSignature pubkey hash signature;
+
+          AuthorizedMoveIfSufficientBalance _sender from amount; (* recieve credit from _sender/relayer *)
+          AuthorizedMoveIfSufficientBalance from _sender fee; (* pay fee for gas fronted by _sender/relayer *)
+          void_cheques[hash] := _sender;
+          e = {_eventname : "CreditSuccess"; initiator : _sender; sender: _sender; recipient : to; amount : amount; fee: fee};
+          event e;
+          (* Prevent sending to a contract address that does not support transfers of token *)
+          msg_to_recipient = {_tag : "RecipientAcceptTransfer"; _recipient : to; _amount : zero; 
+                              sender : _sender; recipient : to; amount : amount};
+          msg_to_sender = {_tag : "TransferSuccessCallBack"; _recipient : _sender; _amount : zero; 
+                          sender : _sender; recipient : to; amount : amount};
+          msgs = two_msgs msg_to_recipient msg_to_sender;
+          send msgs
+        end
+      end
+    end
+  end
+end
+
+procedure ValidateAndCashCheque(cheque: Cheque)
+  match cheque with
+  | Cheque head body tail =>
+    match head with
+    | Header (Pair pubkey to) =>
+      match body with
+      | Body (Pair amount fee) =>
+        match tail with
+        | Sig (Pair nonce signature) =>
+          hash = hash_cheque to amount fee nonce signature _this_address;
+          from = extract_from pubkey;
+          IsChequeValid hash;
+          IsValidSignature pubkey hash signature;
+          
+          AuthorizedMoveIfSufficientBalance from to amount;
+          AuthorizedMoveIfSufficientBalance from _sender fee;
+          void_cheques[hash] := _sender;
+          e = {_eventname : "ChequeSendSuccess"; initiator : _sender; sender: from; recipient : to; amount : amount};
+          event e;
+          (* Prevent sending to a contract address that does not support transfers of token *)
+          msg_to_recipient = {_tag: "RecipientAcceptTransferFrom"; _recipient : to; _amount: zero; 
+                              initiator: _sender; sender : from; recipient: to; amount: amount};
+          msg_to_sender = {_tag: "TransferFromSuccessCallBack"; _recipient: _sender; _amount: zero; 
+                          initiator: _sender; sender: from; recipient: to; amount: amount};
+          msgs = two_msgs msg_to_recipient msg_to_sender;
+          send msgs
+        end
+      end
+    end
+  end
+end
+
+procedure VoidCheque(cheque: Cheque)
+  match cheque with
+  | Cheque head body tail =>
+    match head with
+    | Header (Pair pubkey to) =>
+      match body with
+      | Body (Pair amount fee) =>
+        match tail with
+        | Sig (Pair nonce signature) =>
+          hash = hash_cheque to amount fee nonce signature _this_address;
+          from = extract_from pubkey;
+        
+          IsChequeValid hash;
+          IsValidSignature pubkey hash signature;
+          
+          void_cheques[hash] := _sender;
+          e = {_eventname : "ChequeVoidSuccess"; initiator : _sender; sender: from; recipient : to; amount : amount};
+          event e
+        end
+      end
+    end
   end
 end
 
@@ -202,6 +382,44 @@ transition TransferFrom(from: ByStr20, to: ByStr20, amount: Uint128)
   end
 end
 
+(* @dev: Moves amount tokens from _sender to recipient.                                                 *)
+(* @dev: Balance of recipient will increase. Balance of _sender will decrease.                          *)
+(* @param pubkey:      Public Key of the recipient who is paying the fee, and recieving the credit      *)
+(* @param to:          Address of the recipient whose balance is increased.                             *)
+(* @param amount:      Amount of tokens to be sent.                                                     *)
+(* @param fee:         Reward taken from the transfer recipients balance for the relayer, as they pay for the gas *)
+(* @param nonce:       A random value included in the cheque to make each unique.                       *)
+(* @param signature:   The signature of the cheque by the _sender to authorize spend.                   *)
+transition Claim(pubkey: ByStr33, to: ByStr20, amount: Uint128, fee: Uint128, nonce:Uint128, signature: ByStr64)
+  from = extract_from pubkey;
+  cheque_hash = hash_cheque to amount fee nonce signature _this_address;
+  IsChequeValid cheque_hash;
+  IsValidSignature pubkey cheque_hash signature;
+  
+  AuthorizedMoveIfSufficientBalance _sender to amount;
+  AuthorizedMoveIfSufficientBalance from _sender fee;
+  
+  void_cheques[cheque_hash] := _sender;
+  e = {_eventname : "ClaimSuccess"; initiator : _sender; sender: _sender; recipient : to; amount : amount; fee : fee};
+  event e;
+  (* Prevent sending to a contract address that does not support transfers of token *)
+  msg_to_recipient = {_tag : "RecipientAcceptTransfer"; _recipient : to; _amount : zero; 
+                      sender : _sender; recipient : to; amount : amount};
+  msg_to_sender = {_tag : "TransferSuccessCallBack"; _recipient : _sender; _amount : zero; 
+                  sender : _sender; recipient : to; amount : amount};
+  msgs = two_msgs msg_to_recipient msg_to_sender;
+  send msgs
+end
+
+transition BatchClaim(cheques: List (Pair (Pair (Pair ByStr33 ByStr20) (Pair Uint128 Uint128)) (Pair Uint128 ByStr64)))
+  c =
+    let map = @list_map (Pair (Pair (Pair ByStr33 ByStr20) (Pair Uint128 Uint128)) (Pair Uint128 ByStr64)) Cheque in
+    map map_fn cheques;
+  
+  (* validate & distribute credits batched *)
+  forall c ValidateAndClaim
+end
+
 (* @dev: Moves amount tokens from token_owner to recipient.                                             *)
 (* @dev: Balance of recipient will increase. Balance of token_owner will decrease.                      *)
 (* @param pubkey:      Public Key of the token_owner whose balance is decreased.                        *)
@@ -211,47 +429,33 @@ end
 (* @param nonce:       A random value included in the cheque to make each unique.                       *)
 (* @param signature:   The signature of the cheque by the token owner to authorize spend.               *)
 transition ChequeSend(pubkey: ByStr33, to: ByStr20, amount: Uint128, fee: Uint128, nonce:Uint128, signature: ByStr64)
-  from = builtin schnorr_get_address pubkey;
-  to_hash = builtin sha256hash to;
-  amount_hash = builtin sha256hash amount;
-  contract_hash = builtin sha256hash _this_address;
-  fee_hash = builtin sha256hash fee;
-  nonce_hash = builtin sha256hash nonce;
-  p0_hash = builtin concat to_hash amount_hash;
-  p1_hash = builtin concat p0_hash contract_hash;
-  p2_hash = builtin concat p1_hash fee_hash;
-  p3_hash = builtin concat p2_hash nonce_hash;
-  cheque_hash = builtin to_bystr p3_hash;
-  ev = {_eventname : "CalculatedHash"; from:from ; to_hash:to_hash ; amount_hash:amount_hash; contract_hash:contract_hash;fee_hash:fee_hash ; nonce_hash:nonce_hash ; chequehash:cheque_hash };
-    event ev;
-    cheque_invalid <- exists void_cheques[cheque_hash];
-    match cheque_invalid with 
-    | False =>
-        valid_sig = builtin schnorr_verify pubkey cheque_hash signature;
-        match valid_sig with 
-          | True =>
-            AuthorizedMoveIfSufficientBalance from to amount;
-            AuthorizedMoveIfSufficientBalance from _sender fee;
-            void_cheques[cheque_hash] :=_sender;
-            e = {_eventname : "ChequeSendSuccess"; initiator : _sender; sender: from; recipient : to; amount : amount};
-            event e;
-            (* Prevent sending to a contract address that does not support transfers of token *)
-            msg_to_recipient = {_tag : "RecipientAcceptTransfer"; _recipient : to; _amount : zero; 
-                                sender : _sender; recipient : to; amount : amount};
-            msg_to_sender = {_tag : "TransferSuccessCallBack"; _recipient : _sender; _amount : zero; 
-                            sender : _sender; recipient : to; amount : amount};
-            msgs = two_msgs msg_to_recipient msg_to_sender;
-            send msgs
-          | False =>
-            err = CodeSignatureInvalid;
-            ThrowError err
-        end
-    | True =>
-      err = CodeChequeVoid;
-      ThrowError err
-    end
+  from = extract_from pubkey;
+  cheque_hash = hash_cheque to amount fee nonce signature _this_address;
+  IsChequeValid cheque_hash;
+  IsValidSignature pubkey cheque_hash signature;
+  
+  AuthorizedMoveIfSufficientBalance from to amount;
+  AuthorizedMoveIfSufficientBalance from _sender fee;
+  void_cheques[cheque_hash] := _sender;
+  e = {_eventname : "ChequeSendSuccess"; initiator : _sender; sender: from; recipient : to; amount : amount};
+  event e;
+  (* Prevent sending to a contract address that does not support transfers of token *)
+  msg_to_recipient = {_tag : "RecipientAcceptTransfer"; _recipient : to; _amount : zero; 
+                      sender : _sender; recipient : to; amount : amount};
+  msg_to_sender = {_tag : "TransferSuccessCallBack"; _recipient : _sender; _amount : zero; 
+                  sender : _sender; recipient : to; amount : amount};
+  msgs = two_msgs msg_to_recipient msg_to_sender;
+  send msgs
 end
 
+transition BatchChequeSend(cheques: List (Pair (Pair (Pair ByStr33 ByStr20) (Pair Uint128 Uint128)) (Pair Uint128 ByStr64)))
+  c =
+    let map = @list_map (Pair (Pair (Pair ByStr33 ByStr20) (Pair Uint128 Uint128)) (Pair Uint128 ByStr64)) Cheque in
+    map map_fn cheques;
+  
+  (* validate & cash all cheques batched *)
+  forall c ValidateAndCashCheque
+end
 
 (* @dev: Voids a cheque that _sender does not wish to be processed                                      *)
 (* @dev: Balance of recipient will remain the same.                                                     *)
@@ -261,33 +465,22 @@ end
 (* @param fee:         Reward to be taken from the cheque senders balance if the cheque was processed.  *)
 (* @param nonce:       A random value included in the cheque to make each unique.                       *)
 (* @param signature:   The signature of the cheque by the token owner that authorized the spend.        *)
-transition ChequeVoid(pubkey: ByStr33, to: ByStr20, amount: Uint128, fee: Uint128, nonce:Uint128, signature: ByStr64)
-  from = builtin schnorr_get_address pubkey;
-  to_hash = builtin sha256hash to;
-  amount_hash = builtin sha256hash amount;
-  contract_hash = builtin sha256hash _this_address;
-  fee_hash = builtin sha256hash fee;
-  nonce_hash = builtin sha256hash nonce;
-  p0_hash = builtin concat to_hash amount_hash;
-  p1_hash = builtin concat p0_hash contract_hash;
-  p2_hash = builtin concat p1_hash fee_hash;
-  p3_hash = builtin concat p2_hash nonce_hash;
-  cheque_hash = builtin to_bystr p3_hash;
-  cheque_invalid <- exists void_cheques[cheque_hash];
-    match cheque_invalid with 
-    | False =>
-        valid_sig = builtin schnorr_verify pubkey cheque_hash signature;
-        match valid_sig with 
-          | True =>
-            void_cheques[cheque_hash] :=_sender;
-            e = {_eventname : "ChequeVoidSuccess"; initiator : _sender; sender: from; recipient : to; amount : amount};
-            event e
-          | False =>
-            err = CodeSignatureInvalid;
-            ThrowError err
-        end
-    | True =>
-      err = CodeChequeVoid;
-      ThrowError err
-    end
+transition ChequeVoid(pubkey: ByStr33, to: ByStr20, amount: Uint128, fee: Uint128, nonce: Uint128, signature: ByStr64)
+  from = extract_from pubkey;
+  cheque_hash = hash_cheque to amount fee nonce signature _this_address;
+  IsChequeValid cheque_hash;
+  IsValidSignature pubkey cheque_hash signature;
+
+  void_cheques[cheque_hash] :=_sender;
+  e = {_eventname : "ChequeVoidSuccess"; initiator : _sender; sender: from; recipient : to; amount : amount};
+  event e
+end
+
+transition BatchChequeVoid(cheques: List (Pair (Pair (Pair ByStr33 ByStr20) (Pair Uint128 Uint128)) (Pair Uint128 ByStr64)))
+  c =
+    let map = @list_map (Pair (Pair (Pair ByStr33 ByStr20) (Pair Uint128 Uint128)) (Pair Uint128 ByStr64)) Cheque in
+    map map_fn cheques;
+  
+  (* validate & void cheques batched *)
+  forall c VoidCheque
 end

--- a/reference-contracts/MetaFungibleToken.scilla
+++ b/reference-contracts/MetaFungibleToken.scilla
@@ -382,14 +382,14 @@ transition TransferFrom(from: ByStr20, to: ByStr20, amount: Uint128)
   end
 end
 
-(* @dev: Moves amount tokens from _sender to recipient.                                                 *)
-(* @dev: Balance of recipient will increase. Balance of _sender will decrease.                          *)
-(* @param pubkey:      Public Key of the recipient who is paying the fee, and recieving the credit      *)
-(* @param to:          Address of the recipient whose balance is increased.                             *)
-(* @param amount:      Amount of tokens to be sent.                                                     *)
+(* @dev: Moves amount tokens from _sender to recipient.                                                   *)
+(* @dev: Balance of recipient will increase. Balance of _sender will decrease.                            *)
+(* @param pubkey:      Public Key of the recipient who is paying the fee, and recieving the credit        *)
+(* @param to:          Address of the recipient whose balance is increased.                               *)
+(* @param amount:      Amount of tokens to be sent.                                                       *)
 (* @param fee:         Reward taken from the transfer recipients balance for the relayer, as they pay for the gas *)
-(* @param nonce:       A random value included in the cheque to make each unique.                       *)
-(* @param signature:   The signature of the cheque by the _sender to authorize spend.                   *)
+(* @param nonce:       A random value included in the cheque to make each unique.                         *)
+(* @param signature:   The signature of the cheque by the recipient to authorize paying a fee to receive. *)
 transition Claim(pubkey: ByStr33, to: ByStr20, amount: Uint128, fee: Uint128, nonce:Uint128, signature: ByStr64)
   from = extract_from pubkey;
   cheque_hash = hash_cheque to amount fee nonce signature _this_address;

--- a/zrcs/zrc-3.md
+++ b/zrcs/zrc-3.md
@@ -318,7 +318,7 @@ transition TransferFrom(from: ByStr20, to: ByStr20, amount: Uint128)
 (* @param amount:      Amount of tokens to be sent.                                                                             *)
 (* @param fee:         Reward taken/minings fee from the signer's balance to the relayer.                                       *)
 (* @param nonce:       A random value included in the cheque to make each unique.                                               *)
-(* @param signature:   The signature of the cheque by the token owner to authorize spend.                                       *)
+(* @param signature:   The signature of the cheque by the recipient to authorize paying a fee to receive.                       *)
 ```
 
 **Arguments:**

--- a/zrcs/zrc-3.md
+++ b/zrcs/zrc-3.md
@@ -309,38 +309,43 @@ transition TransferFrom(from: ByStr20, to: ByStr20, amount: Uint128)
 | `_eventname` | `TransferFromSuccess` | Sending is successful.     | `initiator`: `ByStr20`, `sender` : `ByStr20`, `recipient`: `ByStr20`, `amount`: `Uint128`, where `initiator` is the address of an approved_spender,`sender` is the address of the token_owner, `recipient` is the address of the recipient, and `amount` is the amount of fungible tokens to be transferred. |
 | `_eventname` | `Error`               | Sending is not successful. | - emit `CodeInsufficientAllowance` if the allowance of approved_spender is lesser than the specified amount that is to be transferred. <br> - emit `CodeInsufficientFunds` if the balance of the token_owner lesser than the specified amount that is to be transferred.                                     |
 
-#### 9. OperatorSend() (Optional)
+#### 9. Claim() (Optional)
 
-```ocaml
-(* @dev: Moves amount tokens from token_owner to recipient. _sender must be an operator of token_owner. *)
-(* @dev: Balance of recipient will increase. Balance of token_owner will decrease.                      *)
-(* @param from:        Address of the token_owner whose balance is decreased.                           *)
-(* @param to:          Address of the recipient whose balance is increased.                             *)
-(* @param amount:      Amount of tokens to be sent.                                                     *)
-transition OperatorSend(from: ByStr20, to: ByStr20, amount: Uint128)
+(* @dev: Enables a cheque signer to recieve/claim tokens from the `_sender` or relayer, while paying for the relayer's gas fee. *)
+(* @dev: Balance of recipient will increase. Balance of `sender_ will decrease.                                                 *)
+(* @param pubkey:      Public Key of the token_owner whose balance is decreased.                                                *)
+(* @param to:          Address of the recipient whose balance is increased.                                                     *)
+(* @param amount:      Amount of tokens to be sent.                                                                             *)
+(* @param fee:         Reward taken/minings fee from the signer's balance to the relayer.                                       *)
+(* @param nonce:       A random value included in the cheque to make each unique.                                               *)
+(* @param signature:   The signature of the cheque by the token owner to authorize spend.                                       *)
 ```
 
 **Arguments:**
 
-|        | Name     | Type      | Description                                              |
-| ------ | -------- | --------- | -------------------------------------------------------- |
-| @param | `from`   | `ByStr20` | Address of the token_owner whose balance is to decrease. |
-| @param | `to`     | `ByStr20` | Address of the recipient whose balance is to increase.   |
-| @param | `amount` | `Uint128` | Amount of tokens to be sent.                             |
+|        | Name        | Type      | Description                                                        |
+| ------ | ----------- | --------- | ------------------------------------------------------------------ |
+| @param | `pubkey`    | `ByStr33` | Public Key of the token_owner whose balance is to decrease.        |
+| @param | `to`        | `ByStr20` | Address of the recipient whose balance is to increase.             |
+| @param | `amount`    | `Uint128` | Amount of tokens to be sent.                                       |
+| @param | `fee`       | `Uint128` | Reward taken/minings fee from the signer's balance to the relayer. |
+| @param | `nonce`     | `Uint128` | A random value included in the cheque to make each unique.         |
+| @param | `signature` | `ByStr64` | The signature of the cheque by the token owner to authorize spend. |
+
 
 **Messages sent:**
 
-|        | Name                          | Description                                           | Callback Parameters                                                                                                                                                                                                                                                                                  |
-| ------ | ----------------------------- | ----------------------------------------------------- | ---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
-| `_tag` | `RecipientAcceptOperatorSend` | Dummy callback to prevent invalid recipient contract. | `initiator`: `ByStr20`, `sender` : `ByStr20`, `recipient`: `ByStr20`, `amount`: `Uint128`, where `initiator` is the address of an operator,`sender` is the address of the token_owner, `recipient` is the address of the recipient, and `amount` is the amount of fungible tokens to be transferred. |
-| `_tag` | `OperatorSendSuccessCallBack` | Provide the operator the status of the transfer.      | `initiator`: `ByStr20`, `sender` : `ByStr20`, `recipient`: `ByStr20`, `amount`: `Uint128`, where `initiator` is the address of an operator,`sender` is the address of the token_owner, `recipient` is the address of the recipient, and `amount` is the amount of fungible tokens to be transferred. |
+|        | Name                        | Description                                           | Callback Parameters                                                                                                                                                                                                                                                                                  |
+| ------ | --------------------------- | ----------------------------------------------------- | ---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| `_tag` | `RecipientAcceptChequeSend` | Dummy callback to prevent invalid recipient contract. | `initiator`: `ByStr20`, `sender` : `ByStr20`, `recipient`: `ByStr20`, `amount`: `Uint128`, where `initiator` is the address of an operator,`sender` is the address of the token_owner, `recipient` is the address of the recipient, and `amount` is the amount of fungible tokens to be transferred. |
+| `_tag` | `ChequeSendSuccessCallBack` | Provide the relayer the status of the transfer.       | `initiator`: `ByStr20`, `sender` : `ByStr20`, `recipient`: `ByStr20`, `amount`: `Uint128`, where `initiator` is the address of an relayer,`sender` is the address of the token_owner, `recipient` is the address of the recipient, and `amount` is the amount of fungible tokens to be transferred.  |
 
 **Events/Errors:**
 
-|              | Name                  | Description                | Event Parameters                                                                                                                                                                                                                                           |
-| ------------ | --------------------- | -------------------------- | ---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
-| `_eventname` | `OperatorSendSuccess` | Sending is successful.     | `initiator`: `ByStr20` which is the operator's address, `sender`: `ByStr20` which is the token_owner's address, `recipient`: `ByStr20` which is the recipient's address, and `amount`: `Uint128` which is the amount of fungible tokens to be transferred. |
-| `_eventname` | `Error`               | Sending is not successful. | - emit `CodeNotApprovedOperator` if sender is not an approved operator for the token_owner <br> - emit `CodeInsufficientFunds` if the balance of the token_owner is lesser than the specified amount that is to be transferred.                            |
+|              | Name                | Description                | Event Parameters                                                                                                                                                                                                                                                                                                                                                                                                                         |
+| ------------ | ------------------- | -------------------------- | ---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| `_eventname` | `ClaimSuccess` | claim is successful.     | `initiator`: `ByStr20` which is the _sender's address, `sender`: `ByStr20` which is the token_owner's (and `_sender`'s) address, `recipient`: `ByStr20` which is the recipient's address, and `amount`: `Uint128` which is the amount of fungible tokens to be transferred.                                                                                                                                                                               |
+| `_eventname` | `Error`             | Sending is not successful. | - emit `CodeChequeVoid` if the cheque submitted has already been transferred.<br>- emit `CodeInsufficientFunds` if the balance of the token_owner is lesser than the specified amount that is to be transferred.<br> - emit `CodeSignatureInvalid` if the signature of the cheque does not match the cheque parameters. <br> - emit `CodeInvalidSigner` if the signer of the metatransaction is not the owner of the tokens to be moved. |
 
 #### 10. ChequeSend()
 


### PR DESCRIPTION
## Proposed extensions & changes to ZRC

Currently, the [ZRC3 standard](https://github.com/Zilliqa/ZRC/blob/main/zrcs/zrc-3.md) MetaFungible primarily contains "Cheques" as a means of transfering tokens (primarily abstracting `TransferFrom`). I propose the extension - namely `Claim`, to compliment `ChequeSend` by abstracting `Transfer`. This enables the means of meta-transfering tokens, implicitly gated & authorized by the `_sender` (as `Transfer` typically operates), through a hot-wallet or relayer for token distribution. An example could be rewarding users for tasks, or any other forms of remittance.

Its worth noting that through this implementation, the recipient does not require any pre-existing tokens prior, as the `fee` is paid secondary to receiving the initial claim; unless of course if `fee` exceeds the claim `amount`, it will subsequently fail due to insufficient ZRC2 balance.

#### 10. Claim

```ocaml
(* @dev: Enables a cheque signer to recieve/claim tokens from the `_sender` or relayer, while paying for the relayer's gas fee. *)
(* @dev: Balance of recipient will increase. Balance of `sender_ will decrease.                                                 *)
(* @param pubkey:      Public Key of the token_owner whose balance is decreased.                                                *)
(* @param to:          Address of the recipient whose balance is increased.                                                     *)
(* @param amount:      Amount of tokens to be sent.                                                                             *)
(* @param fee:         Reward taken/minings fee from the signer's balance to the relayer.                                       *)
(* @param nonce:       A random value included in the cheque to make each unique.                                               *)
(* @param signature:   The signature of the cheque by the recipient to authorize paying a fee to receive.                       *)
transition Claim(pubkey: ByStr33, to: ByStr20, amount: Uint128, fee: Uint128, nonce:Uint128, signature: ByStr64)
  from = extract_from pubkey;
  cheque_hash = hash_cheque to amount fee nonce signature _this_address;
  IsChequeValid cheque_hash;
  IsValidSignature pubkey cheque_hash signature;
  
  AuthorizedMoveIfSufficientBalance _sender to amount;
  AuthorizedMoveIfSufficientBalance from _sender fee;
  
  void_cheques[cheque_hash] := _sender;
  e = {_eventname : "ClaimSuccess"; initiator : _sender; sender: _sender; recipient : to; amount : amount; fee : fee};
  event e;
  (* Prevent sending to a contract address that does not support transfers of token *)
  msg_to_recipient = {_tag : "RecipientAcceptTransfer"; _recipient : to; _amount : zero; 
                      sender : _sender; recipient : to; amount : amount};
  msg_to_sender = {_tag : "TransferSuccessCallBack"; _recipient : _sender; _amount : zero; 
                  sender : _sender; recipient : to; amount : amount};
  msgs = two_msgs msg_to_recipient msg_to_sender;
  send msgs
end
```

**Arguments:**

|        | Name        | Type      | Description                                                        |
| ------ | ----------- | --------- | ------------------------------------------------------------------ |
| @param | `pubkey`    | `ByStr33` | Public Key of the token_owner whose balance is to decrease.        |
| @param | `to`        | `ByStr20` | Address of the recipient whose balance is to increase.             |
| @param | `amount`    | `Uint128` | Amount of tokens to be sent.                                       |
| @param | `fee`       | `Uint128` | Reward taken/minings fee from the signer's balance to the relayer. |
| @param | `nonce`     | `Uint128` | A random value included in the cheque to make each unique.         |
| @param | `signature` | `ByStr64` | The signature of the cheque by the recipient to authorize paying a fee to receive. |


**Messages sent:**

|        | Name                        | Description                                           | Callback Parameters                                                                                                                                                                                                                                                                                  |
| ------ | --------------------------- | ----------------------------------------------------- | ---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
| `_tag` | `RecipientAcceptChequeSend` | Dummy callback to prevent invalid recipient contract. | `initiator`: `ByStr20`, `sender` : `ByStr20`, `recipient`: `ByStr20`, `amount`: `Uint128`, where `initiator` is the address of an operator,`sender` is the address of the token_owner, `recipient` is the address of the recipient, and `amount` is the amount of fungible tokens to be transferred. |
| `_tag` | `ChequeSendSuccessCallBack` | Provide the relayer the status of the transfer.       | `initiator`: `ByStr20`, `sender` : `ByStr20`, `recipient`: `ByStr20`, `amount`: `Uint128`, where `initiator` is the address of an relayer,`sender` is the address of the token_owner, `recipient` is the address of the recipient, and `amount` is the amount of fungible tokens to be transferred.  |

**Events/Errors:**

|              | Name                | Description                | Event Parameters                                                                                                                                                                                                                                                                                                                                                                                                                         |
| ------------ | ------------------- | -------------------------- | ---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
| `_eventname` | `ClaimSuccess` | Claim is successful.     | `initiator`: `ByStr20` which is the _sender's address, `sender`: `ByStr20` which is the token_owner's (and `_sender`'s) address, `recipient`: `ByStr20` which is the recipient's address, and `amount`: `Uint128` which is the amount of fungible tokens to be transferred.                                                                                                                                                                               |
| `_eventname` | `Error`             | Sending is not successful. | - emit `CodeChequeVoid` if the cheque submitted has already been transferred.<br>- emit `CodeInsufficientFunds` if the balance of the token_owner is lesser than the specified amount that is to be transferred.<br> - emit `CodeSignatureInvalid` if the signature of the cheque does not match the cheque parameters. <br> - emit `CodeInvalidSigner` if the signer of the metatransaction is not the owner of the tokens to be moved. |

Additionally, via batching to reduce gas cost for larger volume:
```
transition BatchClaim(cheques: List (Pair (Pair (Pair ByStr33 ByStr20) (Pair Uint128 Uint128)) (Pair Uint128 ByStr64)))
  (* construct cheque list *)
  c =
    let map = @list_map (Pair (Pair (Pair ByStr33 ByStr20) (Pair Uint128 Uint128)) (Pair Uint128 ByStr64)) Cheque in
    map map_fn cheques;
  
  (* validate & distribute credits batched *)
  forall c ValidateAndClaim
end
```
```
transition BatchChequeSend(cheques: List (Pair (Pair (Pair ByStr33 ByStr20) (Pair Uint128 Uint128)) (Pair Uint128 ByStr64)))
  c =
    let map = @list_map (Pair (Pair (Pair ByStr33 ByStr20) (Pair Uint128 Uint128)) (Pair Uint128 ByStr64)) Cheque in
    map map_fn cheques;

  (* validate & cash all cheques batched *)
  forall c ValidateAndCashCheque
end
```